### PR TITLE
[ENH] Switch regressions to use the pandas implementation

### DIFF
--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -90,20 +90,20 @@ def plot_rolling_risk_factors(
     rolling_risk_multifactor = timeseries.rolling_multifactor_beta(
         returns,
         risk_factors.loc[:, ['SMB', 'HML', 'UMD']],
-        rolling_window=rolling_beta_window)
+        window=rolling_beta_window)
 
     rolling_beta_SMB = timeseries.rolling_beta(
         returns,
         risk_factors['SMB'],
-        rolling_window=rolling_beta_window)
+        window=rolling_beta_window)
     rolling_beta_HML = timeseries.rolling_beta(
         returns,
         risk_factors['HML'],
-        rolling_window=rolling_beta_window)
+        window=rolling_beta_window)
     rolling_beta_UMD = timeseries.rolling_beta(
         returns,
         risk_factors['UMD'],
-        rolling_window=rolling_beta_window)
+        window=rolling_beta_window)
 
     rolling_beta_SMB.plot(color='steelblue', alpha=0.7, ax=ax, **kwargs)
     rolling_beta_HML.plot(color='orangered', alpha=0.7, ax=ax, **kwargs)
@@ -608,10 +608,10 @@ def plot_rolling_beta(returns, benchmark_rets,
     ax.set_title("Rolling Portfolio Beta to S&P 500")
     ax.set_ylabel('Beta')
     rb_1 = timeseries.rolling_beta(
-        returns, benchmark_rets, rolling_window=rolling_beta_window * 2)
+        returns, benchmark_rets, window=rolling_beta_window * 2)['x']
     rb_1.plot(color='steelblue', lw=3, alpha=0.6, ax=ax, **kwargs)
     rb_2 = timeseries.rolling_beta(
-        returns, benchmark_rets, rolling_window=rolling_beta_window * 3)
+        returns, benchmark_rets, window=rolling_beta_window * 3)['x']
     rb_2.plot(color='grey', lw=3, alpha=0.4, ax=ax, **kwargs)
     ax.set_ylim((-2.5, 2.5))
     ax.axhline(rb_1.mean(), color='steelblue', linestyle='--', lw=3)

--- a/pyfolio/tests/test_timeseries.py
+++ b/pyfolio/tests/test_timeseries.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+import unittest
 from nose_parameterized import parameterized
 
 import numpy as np
@@ -8,7 +8,7 @@ import pandas.util.testing as pdt
 from .. import timeseries
 
 
-class TestDrawdown(TestCase):
+class TestDrawdown(unittest.TestCase):
     px_list_1 = np.array(
         [100, 120, 100, 80, 70, 110, 180, 150]) / 100.  # Simple
     px_list_2 = np.array(
@@ -130,7 +130,7 @@ class TestDrawdown(TestCase):
             expected)
 
 
-class TestCumReturns(TestCase):
+class TestCumReturns(unittest.TestCase):
     dt = pd.date_range('2000-1-3', periods=3, freq='D')
 
     @parameterized.expand([
@@ -144,7 +144,7 @@ class TestCumReturns(TestCase):
         pdt.assert_series_equal(output, expected)
 
 
-class TestVariance(TestCase):
+class TestVariance(unittest.TestCase):
 
     @parameterized.expand([
         (1e7, 0.5, 1, 1, -10000000.0)
@@ -159,7 +159,7 @@ class TestVariance(TestCase):
             expected)
 
 
-class TestNormalize(TestCase):
+class TestNormalize(unittest.TestCase):
     dt = pd.date_range('2000-1-3', periods=8, freq='D')
     px_list = [1.0, 1.2, 1.0, 0.8, 0.7, 0.8, 0.8, 0.8]
 
@@ -171,7 +171,7 @@ class TestNormalize(TestCase):
         self.assertTrue(timeseries.normalize(df).equals(expected))
 
 
-class TestAggregateReturns(TestCase):
+class TestAggregateReturns(unittest.TestCase):
     simple_rets = pd.Series(
         [0.1] * 3 + [0] * 497,
         pd.date_range(
@@ -192,7 +192,7 @@ class TestAggregateReturns(TestCase):
             expected)
 
 
-class TestStats(TestCase):
+class TestStats(unittest.TestCase):
     simple_rets = pd.Series(
         [0.1] * 3 + [0] * 497,
         pd.date_range(
@@ -266,7 +266,7 @@ class TestStats(TestCase):
             expected)
 
 
-class TestMultifactor(TestCase):
+class TestMultifactor(unittest.TestCase):
     simple_rets = pd.Series(
         [0.1] * 3 + [0] * 497,
         pd.date_range(
@@ -309,7 +309,7 @@ class TestMultifactor(TestCase):
             expected)
 
 
-class TestPerfStats(TestCase):
+class TestPerfStats(unittest.TestCase):
     simple_rets = pd.Series(
         [0.1] * 3 + [0] * 497,
         pd.date_range(

--- a/pyfolio/tests/test_timeseries.py
+++ b/pyfolio/tests/test_timeseries.py
@@ -7,6 +7,7 @@ import pandas.util.testing as pdt
 
 from .. import timeseries
 
+DECIMAL_PLACES = 9
 
 class TestDrawdown(unittest.TestCase):
     px_list_1 = np.array(
@@ -106,13 +107,13 @@ class TestDrawdown(unittest.TestCase):
         (pd.Series(px_list_1 - 1, index=dt), -0.44000000000000011)
     ])
     def test_max_drawdown(self, df_rets, expected):
-        self.assertEqual(timeseries.max_drawdown(df_rets), expected)
+        self.assertAlmostEqual(timeseries.max_drawdown(df_rets), expected, DECIMAL_PLACES)
 
     @parameterized.expand([
         (pd.Series(px_list_1 - 1, index=dt), -0.44000000000000011)
     ])
     def test_max_drawdown_underwater(self, underwater, expected):
-        self.assertEqual(timeseries.max_drawdown(underwater), expected)
+        self.assertAlmostEqual(timeseries.max_drawdown(underwater), expected, DECIMAL_PLACES)
 
     @parameterized.expand([
         (pd.Series(px_list_1,
@@ -224,18 +225,18 @@ class TestStats(unittest.TestCase):
         (simple_rets, 0.12271674212427248)
     ])
     def test_annual_volatility(self, df_rets, expected):
-        self.assertEqual(timeseries.annual_volatility(df_rets), expected)
+        self.assertAlmostEqual(timeseries.annual_volatility(df_rets), expected, DECIMAL_PLACES)
 
     @parameterized.expand([
         (simple_rets, 'calendar', 1.7112579454508172),
         (simple_rets, 'compound', 1.3297007080039505)
     ])
     def test_sharpe(self, df_rets, returns_style, expected):
-        self.assertEqual(
+        self.assertAlmostEqual(
             timeseries.sharpe_ratio(
                 df_rets,
                 returns_style=returns_style),
-            expected)
+            expected, DECIMAL_PLACES)
 
     @parameterized.expand([
         (simple_rets[:5], 2, '[nan, inf, inf, 11.224972160321828, inf]')
@@ -248,21 +249,21 @@ class TestStats(unittest.TestCase):
         (simple_rets, True, 0.010766923838471554)
     ])
     def test_stability_of_timeseries(self, df_rets, logValue, expected):
-        self.assertEqual(
+        self.assertAlmostEqual(
             timeseries.stability_of_timeseries(
                 df_rets,
                 logValue=logValue),
-            expected)
+            expected, DECIMAL_PLACES)
 
     @parameterized.expand([
         (simple_rets[:5], simple_benchmark[:5], 2, 8.024708101613483e-32)
     ])
-    def test_beta(self, df_rets, benchmark_rets, rolling_window, expected):
+    def test_beta(self, df_rets, benchmark_rets, window, expected):
         self.assertEqual(
             timeseries.rolling_beta(
                 df_rets,
                 benchmark_rets,
-                rolling_window=rolling_window).values.tolist()[2],
+                window=window).values.tolist()[2],
             expected)
 
 
@@ -300,12 +301,12 @@ class TestMultifactor(unittest.TestCase):
             0.002997302427814967])
     ])
     def test_multifactor_beta(
-            self, df_rets, benchmark_df, rolling_window, expected):
+            self, df_rets, benchmark_df, window, expected):
         self.assertEqual(
             timeseries.rolling_multifactor_beta(
                 df_rets,
                 benchmark_df,
-                rolling_window=rolling_window).values.tolist()[2],
+                window=window).values.tolist()[2],
             expected)
 
 
@@ -335,4 +336,4 @@ class TestPerfStats(unittest.TestCase):
         self.assertEqual(timeseries.perf_stats(df_rets,
                                                returns_style=returns_style,
                                                return_as_dict=return_as_dict).values.tolist()[-2:],
-                         expected)
+                               expected)

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -22,12 +22,10 @@ import pandas as pd
 import numpy as np
 import scipy as sp
 import scipy.stats as stats
-import scipy.signal as signal
 from sklearn import preprocessing
 
 import statsmodels.api as sm
 
-import datetime
 
 
 def regression(y, x, add_constant=True):
@@ -36,27 +34,47 @@ def regression(y, x, add_constant=True):
     returns the ols model for situations where
     other statistical values are needed.
 
-    :param y: Series/DataFrame; dependent variable
-    :param x: Series/DataFrame; independent variable(s)
-    :param add_constant: if True a constant term will be added
-                         to the regression model.
-    :return: pandas.stats.ols.OLS; regression model
+    Parameters
+    ----------
+    y : Series/DataFrame
+        dependent variable
+    x : Series/DataFrame
+        independent variable(s)
+    add_constant : boolean <default=True>
+        if True a constant term is added
+        to the regression model.
+
+    returns
+    -------
+    pandas.stats.ols.OLS
+        regression model
     """
     return pd.ols(y=y, x=x, intercept=add_constant)
 
 
 def rolling_regression(y, x, window, add_constant=True):
     """
-    Generalized regression calculation that
+    Generalized rolling regression calculation that
     returns the ols model for situations where
     other statistical values are needed.
 
-    :param y: Series/DataFrame; dependent variable
-    :param x: Series/DataFrame; independent variable(s)
-    :param window: int; number of bars used in the regression window
-    :param add_constant: if True a constant term will be added
-                         to the regression model.
-    :return: pandas.stats.ols.OLS; regression model
+    Parameters
+    ----------
+    y : Series/DataFrame
+        dependent variable
+    x : Series/DataFrame
+        independent variable(s)
+    window : int
+        lookback window length used in
+        the rolling regression
+    add_constant : boolean <default=True>
+        if True a constant term is added
+        to the regression model.
+
+    returns
+    -------
+    pandas.stats.ols.OLS
+        regression model
     """
     return pd.ols(y=y, x=x, window=window,
                   window_type='rolling', intercept=add_constant)

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -410,7 +410,7 @@ def sharpe_ratio(returns, returns_style='compound'):
         return np.nan
 
 
-def stability_of_timeseries(returns, logValue=True, return_ols_model=False):
+def stability_of_timeseries(returns, logValue=True):
     """
     Determines R-squared of a linear fit to the returns.
 
@@ -439,8 +439,6 @@ def stability_of_timeseries(returns, logValue=True, return_ols_model=False):
 
     model = regression(temp_values, X, add_constant=True)
     # TODO: should adjusted rsquared be used?
-    if return_ols_model:
-        return model.r2, model
     return model.r2
 
 
@@ -515,7 +513,7 @@ def out_of_sample_vs_in_sample_returns_kde(
     return kde_diff
 
 
-def calc_multifactor(returns, factors, add_constant=True, return_ols_model=False):
+def calc_multifactor(returns, factors, add_constant=True):
     """
     Computes multiple ordinary least squares linear fits, and returns fit parameters.
 
@@ -532,13 +530,10 @@ def calc_multifactor(returns, factors, add_constant=True, return_ols_model=False
         Fit parameters.
     """
     model = regression(returns, factors, add_constant=add_constant)
-    if return_ols_model:
-        return model.beta, model
     return model.beta
 
 
-def rolling_beta(returns, benchmark_rets, window=63,
-                 add_constant=True, return_ols_model=False):
+def rolling_beta(returns, benchmark_rets, window=63, add_constant=True):
     """
     Determines the rolling beta of a strategy.
 
@@ -561,14 +556,13 @@ def rolling_beta(returns, benchmark_rets, window=63,
     See https://en.wikipedia.org/wiki/Beta_(finance) for more details.
     """
 
-    model = rolling_regression(returns, benchmark_rets, window, add_constant=add_constant)
-    if return_ols_model:
-        return model.beta, model
+    model = rolling_regression(returns, benchmark_rets,
+                               window, add_constant=add_constant)
     return model.beta
 
 
-def rolling_multifactor_beta(returns, df_multi_factor, window=63,
-                             add_constant=True, return_ols_model=False):
+def rolling_multifactor_beta(returns, df_multi_factor,
+                             window=63, add_constant=True):
     """
     Determines the rolling beta of multiple factors.
 
@@ -590,13 +584,12 @@ def rolling_multifactor_beta(returns, df_multi_factor, window=63,
     -----
     See https://en.wikipedia.org/wiki/Beta_(finance) for more details.
     """
-    model = rolling_regression(returns, df_multi_factor, window, add_constant=add_constant)
-    if return_ols_model:
-        return model.beta, model
+    model = rolling_regression(returns, df_multi_factor,
+                               window, add_constant=add_constant)
     return model.beta
 
 
-def calc_alpha_beta(returns, benchmark_rets, return_ols_model=False):
+def calc_alpha_beta(returns, benchmark_rets):
     """
     Calculates both alpha and beta.
 
@@ -615,10 +608,7 @@ def calc_alpha_beta(returns, benchmark_rets, return_ols_model=False):
         Beta.
     """
     model = regression(returns, benchmark_rets, add_constant=True)
-
     beta, alpha = model.beta
-    if return_ols_model:
-        return alpha * 252, beta, model
 
     return alpha * 252, beta
 


### PR DESCRIPTION
There were several different methods to calculate regressions
being used. We should use a consistent method everywhere
and Pandas does fast rolling regressions with all sorts of
bells and whistles.