### PR TITLE
[BUG] Ensure utc timezones

### DIFF
--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -38,7 +38,7 @@ import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 import seaborn as sns
 
-from . utils import normalize_date
+from . utils import get_utc_date
 
 
 @plotting_context
@@ -78,8 +78,8 @@ def create_returns_tear_sheet(returns, live_start_date=None,
         benchmark_rets = utils.get_symbol_rets('SPY')
         # If the strategy's history is longer than the benchmark's, limit
         # strategy
-        benchmark_start = normalize_date(benchmark_rets.index[0])
-        returns_start = normalize_date(returns.index[0])
+        benchmark_start = get_utc_date(benchmark_rets.index[0])
+        returns_start = get_utc_date(returns.index[0])
         if returns_start < benchmark_start:
             returns = returns[returns.index > benchmark_rets.index[0]]
 
@@ -311,8 +311,8 @@ def create_interesting_times_tear_sheet(
         benchmark_rets = utils.get_symbol_rets('SPY')
         # If the strategy's history is longer than the benchmark's, limit
         # strategy
-        benchmark_start = normalize_date(benchmark_rets.index[0])
-        returns_start = normalize_date(returns.index[0])
+        benchmark_start = get_utc_date(benchmark_rets.index[0])
+        returns_start = get_utc_date(returns.index[0])
         if returns_start < benchmark_start:
             returns = returns[returns.index > benchmark_rets.index[0]]
 
@@ -489,8 +489,8 @@ def create_full_tear_sheet(returns, positions=None, transactions=None,
         benchmark_rets = utils.get_symbol_rets('SPY')
 
     # If the strategy's history is longer than the benchmark's, limit strategy
-    benchmark_start = normalize_date(benchmark_rets.index[0])
-    returns_start = normalize_date(returns.index[0])
+    benchmark_start = get_utc_date(benchmark_rets.index[0])
+    returns_start = get_utc_date(returns.index[0])
     if returns_start < benchmark_start:
         returns = returns[returns.index > benchmark_rets.index[0]]
 

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -32,7 +32,6 @@ except ImportError:
 import numpy as np
 import scipy.stats
 import pandas as pd
-import pytz
 
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -38,6 +38,8 @@ import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 import seaborn as sns
 
+from . utils import normalize_date
+
 
 @plotting_context
 def create_returns_tear_sheet(returns, live_start_date=None,
@@ -76,8 +78,8 @@ def create_returns_tear_sheet(returns, live_start_date=None,
         benchmark_rets = utils.get_symbol_rets('SPY')
         # If the strategy's history is longer than the benchmark's, limit
         # strategy
-        benchmark_start = benchmark_rets.index[0].astimezone(pytz.UTC)
-        returns_start = returns.index[0].astimezone(pytz.UTC)
+        benchmark_start = normalize_date(benchmark_rets.index[0])
+        returns_start = normalize_date(returns.index[0])
         if returns_start < benchmark_start:
             returns = returns[returns.index > benchmark_rets.index[0]]
 
@@ -309,8 +311,8 @@ def create_interesting_times_tear_sheet(
         benchmark_rets = utils.get_symbol_rets('SPY')
         # If the strategy's history is longer than the benchmark's, limit
         # strategy
-        benchmark_start = benchmark_rets.index[0].astimezone(pytz.UTC)
-        returns_start = returns.index[0].astimezone(pytz.UTC)
+        benchmark_start = normalize_date(benchmark_rets.index[0])
+        returns_start = normalize_date(returns.index[0])
         if returns_start < benchmark_start:
             returns = returns[returns.index > benchmark_rets.index[0]]
 
@@ -487,8 +489,8 @@ def create_full_tear_sheet(returns, positions=None, transactions=None,
         benchmark_rets = utils.get_symbol_rets('SPY')
 
     # If the strategy's history is longer than the benchmark's, limit strategy
-    benchmark_start = benchmark_rets.index[0].astimezone(pytz.UTC)
-    returns_start = returns.index[0].astimezone(pytz.UTC)
+    benchmark_start = normalize_date(benchmark_rets.index[0])
+    returns_start = normalize_date(returns.index[0])
     if returns_start < benchmark_start:
         returns = returns[returns.index > benchmark_rets.index[0]]
 

--- a/pyfolio/utils.py
+++ b/pyfolio/utils.py
@@ -94,10 +94,10 @@ def round_two_dec_places(x):
     return np.round(x, 2)
 
 
-def normalize_date(dt):
+def get_utc_date(dt):
     """
-    returns the timestamp/DatetimeIndex
-    normalized to midnight UTC time
+    returns the UTC representation
+    of a timestamp or DatetimeIndex
 
     Parameters
     ----------
@@ -108,7 +108,7 @@ def normalize_date(dt):
     Returns
     -------
     same dtype as dt
-        the date(s) normalized to midnight UTC
+        UTC representation of the input date(s)
     """
     try:
         dt = dt.tz_localize(pytz.UTC)
@@ -140,7 +140,7 @@ def default_returns_func(symbol):
             if datetime.now() - pd.to_datetime(
                     getmtime(filepath), unit='s') < pd.Timedelta(days=1):
                 rets = pd.read_hdf(filepath, 'df')
-                rets.index = normalize_date(rets.index)
+                rets.index = get_utc_date(rets.index)
         except:
             pass
 
@@ -148,7 +148,7 @@ def default_returns_func(symbol):
         px = web.get_data_yahoo(symbol, start='1/1/1970')
         px = pd.DataFrame.rename(px, columns={'Adj Close': 'AdjClose'})
         px.columns.name = symbol
-        px.index = normalize_date(px.index)
+        px.index = get_utc_date(px.index)
         rets = px.AdjClose.pct_change().dropna()
 
         if symbol == 'SPY':


### PR DESCRIPTION
In research there was an issue converting timestamps to UTC, this makes sure the data returned by `get_symbol_rets` is tz-aware with a UTC timezone. It also added a method `get_utc_date` which returns the UTC representation of a timestamp. If the date is not tz-aware, it is given a UTC timezone, if it is,
it is simply converted to UTC.

I did not have the dates normalized to midnight so that doing intraday analysis is still possible in the future.

Hopefully this fixes the issues in research!