### PR TITLE
[BUG] KeyError Fix in pos.get_top_long_short_abs

### DIFF
--- a/pyfolio/pos.py
+++ b/pyfolio/pos.py
@@ -96,7 +96,7 @@ def get_top_long_short_abs(positions, top=10):
     positions = positions.drop('cash', axis='columns')
     df_max = positions.max()
     df_min = positions.min()
-    df_abs_max = positions.abs()
+    df_abs_max = positions.abs().max()
     df_top_long = df_max[df_max > 0].nlargest(top)
     df_top_short = df_min[df_min < 0].nsmallest(top)
     df_top_abs = df_abs_max.nlargest(top)

--- a/pyfolio/pos.py
+++ b/pyfolio/pos.py
@@ -94,12 +94,12 @@ def get_top_long_short_abs(positions, top=10):
     """
 
     positions = positions.drop('cash', axis='columns')
-    df_max = positions.max().sort(inplace=False, ascending=False)
-    df_min = positions.min().sort(inplace=False, ascending=True)
-    df_abs_max = positions.abs().max().sort(inplace=False, ascending=False)
-    df_top_long = df_max[df_max > 0][:top]
-    df_top_short = df_min[df_min < 0][:top]
-    df_top_abs = df_abs_max[:top]
+    df_max = positions.max()
+    df_min = positions.min()
+    df_abs_max = positions.abs()
+    df_top_long = df_max[df_max > 0].nlargest(top)
+    df_top_short = df_min[df_min < 0].nsmallest(top)
+    df_top_abs = df_abs_max.nlargest(top)
     return df_top_long, df_top_short, df_top_abs
 
 


### PR DESCRIPTION
Using `series[:N]` in research is causing a KeyError. To fix this
I cleaned up the function by using `series.nlargest(N)`. This
also allowed me to delete the sorting methods from the function.