### PR TITLE
Refactor get symbol rets

### DIFF
--- a/pyfolio/utils.py
+++ b/pyfolio/utils.py
@@ -25,7 +25,6 @@ from datetime import datetime
 
 import pandas as pd
 import numpy as np
-import zlib
 import pandas.io.data as web
 
 import zipfile
@@ -49,24 +48,6 @@ def pyfolio_root():
 
 def data_path(name):
     return join(pyfolio_root(), 'data', name)
-
-
-def json_to_obj(json):
-    """
-    Converts a JSON string to a DataFrame.
-
-    Parameters
-    ----------
-    json : str
-        Data to convert.
-
-    Returns
-    -------
-    pd.DataFrame
-        The converted data.
-    """
-
-    return pd.json.loads(str(zlib.decompress(json)))
 
 
 def one_dec_places(x, pos):

--- a/pyfolio/utils.py
+++ b/pyfolio/utils.py
@@ -20,6 +20,7 @@ from os.path import (
     getmtime,
     join,
 )
+import warnings
 
 from datetime import datetime
 
@@ -116,7 +117,13 @@ def default_returns_func(symbol, start=None, end=None):
             # Download most-recent SPY to update cache
             rets = get_symbol_from_yahoo(symbol, start='1/1/1970',
                                          end=datetime.now())
-            rets.to_hdf(filepath, 'df')
+            try:
+                rets.to_hdf(filepath, 'df')
+            except IOError as e:
+                warnings.warn('Could not update cache {}.'
+                              'Exception: {}'.format(filepath, e),
+                              UserWarning)
+
         rets = rets[start:end]
     else:
         rets = get_symbol_from_yahoo(symbol, start=start, end=end)

--- a/pyfolio/utils.py
+++ b/pyfolio/utils.py
@@ -96,8 +96,11 @@ def default_returns_func(symbol, start=None, end=None):
         Daily returns for the symbol.
          - See full explanation in tears.create_full_tear_sheet (returns).
     """
-    start = '1/1/1970' if start is None else start
-    end = datetime.now() if end is None else end
+    if start is None:
+        start = '1/1/1970'
+    if end is None:
+        end = datetime.now()
+
     start = pd.Timestamp(start)
     end = pd.Timestamp(end)
 


### PR DESCRIPTION
Add start and end date kws to get_symbol_rets and refactor caching logic to only update cache if necessary.

Closes https://github.com/quantopian/pyfolio/issues/95 and https://github.com/quantopian/pyfolio/issues/90