### PR TITLE
[BUG] makes get_utc_timestamp work with datetime.datetime objs.

### DIFF
--- a/pyfolio/utils.py
+++ b/pyfolio/utils.py
@@ -90,6 +90,7 @@ def get_utc_timestamp(dt):
     same type as input
         date(s) converted to UTC
     """
+    dt = pd.to_datetime(dt)
     try:
         dt = dt.tz_localize('UTC')
     except TypeError:


### PR DESCRIPTION
Python datetimes were throwing an error in `get_utc_timestamp`,
this fixes that issue for me locally. I used `pd.to_datetime` to
ensure that pd.Timestamps are used. The method works for arrays
as well as individual datetimes.

The example NBs run without error for me locally with this change.