### PR TITLE
PERF speed up for get_txn_vol calculation

### DIFF
--- a/pyfolio/txn.py
+++ b/pyfolio/txn.py
@@ -99,17 +99,14 @@ def get_txn_vol(transactions):
          - See full explanation in tears.create_full_tear_sheet.
     """
 
-    txn_vol = transactions.reset_index().groupby('index').apply(
-        lambda ser: (
-            ser['amount'].abs() *
-            ser['price']).sum())
-    txn_amount = transactions.reset_index().groupby(
-        'index')['amount'].apply(lambda ser: ser.abs().sum())
-    transactions_out = pd.concat([txn_vol, txn_amount], axis=1)
-    transactions_out.columns = ['txn_volume', 'txn_shares']
-    transactions_out.index = transactions_out.index.normalize()
-
-    return transactions_out
+    amounts = transactions.amount.abs()
+    prices = transactions.price
+    values = amounts * prices
+    daily_amounts = amounts.groupby(amounts.index).sum()
+    daily_values = values.groupby(values.index).sum()
+    daily_amounts.name = "txn_shares"
+    daily_values.name = "txn_volume"
+    return pd.concat([daily_values, daily_amounts], axis=1)
 
 
 def create_txn_profits(transactions):


### PR DESCRIPTION
Straight forward refactor of get_txn_vol. The lambda
statements made the function hard to read and much slower
so I got rid of them.

Speed stats:
old func: 1 loops, best of 3: 399 ms per loop
new func: 100 loops, best of 3: 10.2 ms per loop