### PR TITLE
TST: Added tests for get_turnover

### DIFF
--- a/pyfolio/tests/test_pos.py
+++ b/pyfolio/tests/test_pos.py
@@ -7,14 +7,17 @@ from pandas import (
     date_range,
     Timestamp
 )
-from pandas.util.testing import assert_frame_equal
+from pandas.util.testing import (assert_frame_equal,
+                                 assert_series_equal)
 from numpy import (
     absolute,
     arange,
     zeros_like,
 )
 
-from pyfolio.pos import get_portfolio_alloc, extract_pos
+from pyfolio.pos import (get_portfolio_alloc,
+                         extract_pos,
+                         get_turnover)
 
 
 class PositionsTestCase(TestCase):
@@ -71,3 +74,50 @@ class PositionsTestCase(TestCase):
         expected.columns.name = 'sid'
 
         assert_frame_equal(result, expected)
+
+    def test_get_turnover(self):
+        """
+        Tests turnover using a 20 day period.
+
+        With no transactions the turnover should be 0.
+
+        with 100% of the porfolio value traded each day
+        the daily turnover rate should be 0.5.
+
+        For monthly turnover it should be the sum
+        of the daily turnovers because 20 days < 1 month.
+
+        e.g (20 days) * (0.5 daily turn) = 10x monthly turnover rate.
+        """
+        dates = date_range(start='2015-01-01', freq='D', periods=20)
+
+        positions = DataFrame([[0.0, 10.0]]*len(dates),
+                              columns=[0, 'cash'], index=dates)
+        transactions = DataFrame([[0, 0]]*len(dates),
+                                 columns=['txn_volume', 'txn_shares'],
+                                 index=dates)
+
+        # Test with no transactions
+        expected = Series([0.0]*len(dates), index=dates)
+        result = get_turnover(transactions, positions)
+        assert_series_equal(result, expected)
+
+        # Monthly freq
+        index = date_range('01-01-2015', freq='M', periods=1)
+        expected = Series([0.0], index=index)
+        result = get_turnover(transactions, positions, period='M')
+        assert_series_equal(result, expected)
+
+        # Test with 0.5 daily turnover
+        transactions = DataFrame([[10.0, 0]]*len(dates),
+                                 columns=['txn_volume', 'txn_shares'],
+                                 index=dates)
+
+        expected = Series([0.5]*len(dates), index=dates)
+        result = get_turnover(transactions, positions)
+        assert_series_equal(result, expected)
+
+        # Monthly freq: should be the sum of the daily freq
+        result = get_turnover(transactions, positions, period='M')
+        expected = Series([10.0], index=index)
+        assert_series_equal(result, expected)


### PR DESCRIPTION
This added a simple test case for get_turnover.
1. No transactions -> no turnover
2. 100% value traded daily -> 50% daily turnover

This was repeated with a monthly freq, I used 20 days
so the monthly result should be the sum of the daily result.