### PR TITLE
ENH Add volatility matching to cumulative returns plot.

### DIFF
--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -549,6 +549,7 @@ def plot_rolling_returns(
         live_start_date=None,
         cone_std=None,
         legend_loc='best',
+        volatility_match=False,
         ax=None, **kwargs):
     """Plots cumulative rolling returns versus some benchmarks'.
 
@@ -575,6 +576,10 @@ def plot_rolling_returns(
              centered around a linear regression.
     legend_loc : matplotlib.loc, optional
         The location of the legend on the plot.
+    volatility_match : bool, optional
+        Whether to normalize the volatility of the returns to those of the
+        benchmark returns. This helps compare strategies with different
+        volatilities. Requires passing of benchmark_rets.
     ax : matplotlib.Axes, optional
         Axes upon which to plot.
     **kwargs, optional
@@ -590,7 +595,15 @@ def plot_rolling_returns(
     if ax is None:
         ax = plt.gca()
 
-    df_cum_rets = timeseries.cum_returns(returns, 1.0)
+    if volatility_match and benchmark_rets is None:
+        raise ValueError('volatility_match requires passing of benchmark_rets.')
+    elif volatility_match and benchmark_rets is not None:
+        df_cum_rets = timeseries.cum_returns(
+            (returns / returns.std()) * benchmark_rets.loc[returns.index].std(),
+            1.0
+        )
+    else:
+        df_cum_rets = timeseries.cum_returns(returns, 1.0)
 
     y_axis_formatter = FuncFormatter(utils.one_dec_places)
     ax.yaxis.set_major_formatter(FuncFormatter(y_axis_formatter))

--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -596,10 +596,12 @@ def plot_rolling_returns(
         ax = plt.gca()
 
     if volatility_match and benchmark_rets is None:
-        raise ValueError('volatility_match requires passing of benchmark_rets.')
+        raise ValueError('volatility_match requires passing of'
+                         'benchmark_rets.')
     elif volatility_match and benchmark_rets is not None:
+        bmark_vol = benchmark_rets.loc[returns.index].std()
         df_cum_rets = timeseries.cum_returns(
-            (returns / returns.std()) * benchmark_rets.loc[returns.index].std(),
+            (returns / returns.std()) * bmark_vol,
             1.0
         )
     else:

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -193,28 +193,30 @@ def create_returns_tear_sheet(returns, live_start_date=None,
                              live_start_date=live_start_date)
 
     if live_start_date is not None:
-        vertical_sections = 10
+        vertical_sections = 11
         live_start_date = utils.get_utc_timestamp(live_start_date)
     else:
-        vertical_sections = 9
+        vertical_sections = 10
 
     fig = plt.figure(figsize=(14, vertical_sections * 6))
     gs = gridspec.GridSpec(vertical_sections, 3, wspace=0.5, hspace=0.5)
     ax_rolling_returns = plt.subplot(gs[:2, :])
-    ax_rolling_beta = plt.subplot(gs[2, :], sharex=ax_rolling_returns)
-    ax_rolling_sharpe = plt.subplot(gs[3, :], sharex=ax_rolling_returns)
-    ax_rolling_risk = plt.subplot(gs[4, :], sharex=ax_rolling_returns)
-    ax_drawdown = plt.subplot(gs[5, :], sharex=ax_rolling_returns)
-    ax_underwater = plt.subplot(gs[6, :], sharex=ax_rolling_returns)
-    ax_monthly_heatmap = plt.subplot(gs[7, 0])
-    ax_annual_returns = plt.subplot(gs[7, 1])
-    ax_monthly_dist = plt.subplot(gs[7, 2])
-    ax_return_quantiles = plt.subplot(gs[8, :])
+    ax_rolling_returns_vol_match = plt.subplot(gs[2, :],
+                                               sharex=ax_rolling_returns)
+    ax_rolling_beta = plt.subplot(gs[3, :], sharex=ax_rolling_returns)
+    ax_rolling_sharpe = plt.subplot(gs[4, :], sharex=ax_rolling_returns)
+    ax_rolling_risk = plt.subplot(gs[5, :], sharex=ax_rolling_returns)
+    ax_drawdown = plt.subplot(gs[6, :], sharex=ax_rolling_returns)
+    ax_underwater = plt.subplot(gs[7, :], sharex=ax_rolling_returns)
+    ax_monthly_heatmap = plt.subplot(gs[8, 0])
+    ax_annual_returns = plt.subplot(gs[8, 1])
+    ax_monthly_dist = plt.subplot(gs[8, 2])
+    ax_return_quantiles = plt.subplot(gs[9, :])
 
     if live_start_date is not None:
-        ax_daily_similarity_scale = plt.subplot(gs[9, 0])
-        ax_daily_similarity_no_var = plt.subplot(gs[9, 1])
-        ax_daily_similarity_no_var_no_mean = plt.subplot(gs[9, 2])
+        ax_daily_similarity_scale = plt.subplot(gs[10, 0])
+        ax_daily_similarity_no_var = plt.subplot(gs[10, 1])
+        ax_daily_similarity_no_var_no_mean = plt.subplot(gs[10, 2])
 
     plotting.plot_rolling_returns(
         returns,
@@ -222,6 +224,16 @@ def create_returns_tear_sheet(returns, live_start_date=None,
         live_start_date=live_start_date,
         cone_std=cone_std,
         ax=ax_rolling_returns)
+
+    plotting.plot_rolling_returns(
+        returns,
+        benchmark_rets=benchmark_rets,
+        live_start_date=live_start_date,
+        cone_std=cone_std,
+        volatility_match=True,
+        ax=ax_rolling_returns_vol_match)
+    ax_rolling_returns_vol_match.set_title(
+        'Cumulative returns volatility matched to benchmark.')
 
     plotting.plot_rolling_beta(
         returns, benchmark_rets, ax=ax_rolling_beta)


### PR DESCRIPTION
Adds a new row that shows the cum returns normalized to have the same volatility as the benchmark over the same period:

![image](https://cloud.githubusercontent.com/assets/674200/9436947/783f708a-4a53-11e5-8026-de34f074b356.png)

CC @Jstauth 