### PR TITLE
MAINT replace volume hist plot with turnover hist plot

### DIFF
--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -1053,6 +1053,39 @@ def plot_turnover(returns, transactions, positions,
     return ax
 
 
+def plot_daily_turnover_hist(transactions, positions,
+                             ax=None, **kwargs):
+    """Plots a histogram of daily turnover rates.
+
+    Parameters
+    ----------
+    transactions : pd.DataFrame
+        Daily transaction volume and dollar ammount.
+         - See full explanation in tears.create_full_tear_sheet.
+    positions : pd.DataFrame
+        Daily net position values.
+         - See full explanation in tears.create_full_tear_sheet.
+    ax : matplotlib.Axes, optional
+        Axes upon which to plot.
+    **kwargs, optional
+        Passed to seaborn plotting function.
+
+    Returns
+    -------
+    ax : matplotlib.Axes
+        The axes that were plotted on.
+
+    """
+
+    if ax is None:
+        ax = plt.gca()
+    turnover = pos.get_turnover(transactions, positions, period=None)
+    sns.distplot(turnover, ax=ax, **kwargs)
+    ax.set_title('Distribution of Daily Turnover Rates')
+    ax.set_xlabel('Turnover Rate')
+    return ax
+
+
 def plot_daily_volume(returns, transactions, ax=None, **kwargs):
     """Plots trading volume per day vs. date.
 

--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -1125,35 +1125,6 @@ def plot_daily_volume(returns, transactions, ax=None, **kwargs):
     return ax
 
 
-def plot_volume_per_day_hist(transactions, ax=None, **kwargs):
-    """Plots a histogram of trading volume per day.
-
-    Parameters
-    ----------
-    transactions : pd.DataFrame
-        Daily transaction volume and dollar ammount.
-         - See full explanation in tears.create_full_tear_sheet.
-    ax : matplotlib.Axes, optional
-        Axes upon which to plot.
-    **kwargs, optional
-        Passed to seaborn plotting function.
-
-    Returns
-    -------
-    ax : matplotlib.Axes
-        The axes that were plotted on.
-
-    """
-
-    if ax is None:
-        ax = plt.gca()
-
-    sns.distplot(transactions.txn_volume, ax=ax, **kwargs)
-    ax.set_title('Distribution of Daily Trading Volume')
-    ax.set_xlabel('Volume')
-    return ax
-
-
 def plot_daily_returns_similarity(returns_backtest, returns_live,
                                   title='', scale_kws=None, ax=None,
                                   **kwargs):

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -383,7 +383,7 @@ def create_txn_tear_sheet(
     gs = gridspec.GridSpec(3, 3, wspace=0.5, hspace=0.5)
     ax_turnover = plt.subplot(gs[0, :])
     ax_daily_volume = plt.subplot(gs[1, :], sharex=ax_turnover)
-    ax_daily_volume_hist = plt.subplot(gs[2, :])
+    ax_turnover_hist = plt.subplot(gs[2, :])
 
     plotting.plot_turnover(
         returns,
@@ -393,7 +393,8 @@ def create_txn_tear_sheet(
 
     plotting.plot_daily_volume(returns, transactions, ax=ax_daily_volume)
 
-    plotting.plot_volume_per_day_hist(transactions, ax=ax_daily_volume_hist)
+    plotting.plot_daily_turnover_hist(transactions, positions,
+                                      ax=ax_turnover_hist)
 
     if return_fig:
         return fig


### PR DESCRIPTION
This replaces the volume histogram with a histogram of the
daily turnover rate.

The volume plot is still in the txn_tearsheet because I did not want to change the
size of the grid in case it breaks something or looks funny. 