### PR TITLE
MAINT Fix gross leverage - round 2

### DIFF
--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import division
-import warnings
 
 import pandas as pd
 import numpy as np
@@ -799,7 +798,7 @@ def plot_gross_leverage(returns, gross_lev, ax=None, **kwargs):
 
 
 def plot_exposures(returns, positions_alloc, ax=None, **kwargs):
-    """Plots a cake chart of long, short, and cash exposure.
+    """Plots a cake chart of the long and short exposure.
 
     Parameters
     ----------
@@ -818,23 +817,19 @@ def plot_exposures(returns, positions_alloc, ax=None, **kwargs):
     -------
     ax : matplotlib.Axes
         The axes that were plotted on.
-
-"""
+    """
 
     if ax is None:
         ax = plt.gca()
 
     df_long_short = pos.get_long_short_pos(positions_alloc)
 
-    if np.any(df_long_short.cash < 0):
-        warnings.warn('Negative cash, taking absolute for area plot.')
-        df_long_short = df_long_short.abs()
     df_long_short.plot(
-        kind='area', color=['lightblue', 'green', 'coral'], alpha=1.0,
+        kind='area', color=['lightblue', 'green'], alpha=1.0,
         ax=ax, **kwargs)
     df_cum_rets = timeseries.cum_returns(returns, starting_value=1)
     ax.set_xlim((df_cum_rets.index[0], df_cum_rets.index[-1]))
-    ax.set_title("Long/Short/Cash Exposure")
+    ax.set_title("Long/Short Exposure")
     ax.set_ylabel('Exposure')
     ax.set_xlabel('')
     return ax

--- a/pyfolio/pos.py
+++ b/pyfolio/pos.py
@@ -37,39 +37,31 @@ def get_portfolio_alloc(positions):
     )
 
 
-def get_long_short_pos(positions, gross_lev=1.):
+def get_long_short_pos(positions):
     """
-    Determines the long amount, short amount, and cash of a portfolio.
+    Determines the long and short allocations in a portfolio.
 
     Parameters
     ----------
     positions : pd.DataFrame
         The positions that the strategy takes over time.
-    gross_lev : float, optional
-        The porfolio's gross leverage (default 1).
 
     Returns
     -------
     df_long_short : pd.DataFrame
-        Net long, short, and cash positions.
+        Long and short allocations as a decimal
+        percentage of the total net liquidation
     """
 
-    positions_wo_cash = positions.drop('cash', axis='columns')
-    df_long = positions_wo_cash.apply(lambda x: x[x > 0].sum(), axis='columns')
-    df_short = - \
-        positions_wo_cash.apply(lambda x: x[x < 0].sum(), axis='columns')
-    # Shorting positions adds to cash
-    df_cash = positions.cash.abs() - df_short
-    df_long_short = pd.DataFrame({'long': df_long,
-                                  'short': df_short,
-                                  'cash': df_cash})
-    # Renormalize
-    df_long_short /= df_long_short.sum(axis='columns')
+    pos_wo_cash = positions.drop('cash', axis=1)
+    longs = pos_wo_cash[pos_wo_cash > 0].sum(axis=1)
+    shorts = pos_wo_cash[pos_wo_cash < 0].abs().sum(axis=1)
+    cash = positions.cash
+    net_liquidation = longs - shorts + cash
+    df_long_short = pd.DataFrame({'long': longs,
+                                  'short': shorts})
 
-    # Renormalize to leverage
-    df_long_short *= gross_lev
-
-    return df_long_short
+    return df_long_short / net_liquidation
 
 
 def get_top_long_short_abs(positions, top=10):


### PR DESCRIPTION
This is separate branch that changes the `long_short_exposure`
function to match gross leverage.

https://github.com/quantopian/pyfolio/pull/140 is the same thing, but my git repo 
got out of whack while working on the other branch so I figured I'd start again.

This only changes the code in pyfolio, I did not re-run the notebook
since it seemed to cause an issue last time. I'll submit the notebook
change in a separate PR.