### PR TITLE
Give more meaningful error messages on empty backtest.

### DIFF
--- a/pyfolio/utils.py
+++ b/pyfolio/utils.py
@@ -346,6 +346,8 @@ def extract_rets_pos_txn_from_zipline(backtest):
         df = pd.DataFrame(pos_row)
         df.index = [dt] * len(df)
         raw_positions.append(df)
+    if not raw_positions:
+        raise ValueError("The backtest does not have any positions.")
     positions = pd.concat(raw_positions)
     positions = pos.extract_pos(positions, backtest.ending_cash)
     transactions_frame = txn.make_transaction_frame(backtest.transactions)


### PR DESCRIPTION
Currently pyfolio throws an error with an empty backtest (i.e. backtest that have no position)  An issue which took me a short while to debug, hopefully clarifying the error message will help the others.

Previously on calling `extract_rets_pos_txn_from_zipline` on an empty backtest we will be greeted with an exception:
```
pyfolio/pos.pyc in extract_pos(positions, cash)
AttributeError: 'DataFrame' object has no attribute 'amount'
```
This is just a change to make the error message more obvious.