### PR TITLE
[BUG] Fix #145 drawdown overlaps

### DIFF
--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -66,15 +66,15 @@ def create_full_tear_sheet(returns, positions=None, transactions=None,
         Daily net position values.
          - Time series of dollar amount invested in each position and cash.
          - Days where stocks are not held can be represented by 0 or NaN.
+         - Non-working capital is labelled 'cash'
          - Example:
             index         'AAPL'         'MSFT'          cash
             2004-01-09    13939.3800     -14012.9930     711.5585
             2004-01-12    14492.6300     -14624.8700     27.1821
             2004-01-13    -13853.2800    13653.6400      -43.6375
     transactions : pd.DataFrame, optional
-        Daily transaction volume and dollar ammount.
-        -  Time series of dollar amount of transactions per day,
-            and number of shares traded per day.
+        Daily transaction quantity (txn_shares) and dollar amount
+        (txn_volume).
         - Example:
             index         txn_volume      txn_shares
             2004-01-09    99288.441805    6361

--- a/pyfolio/tests/test_timeseries.py
+++ b/pyfolio/tests/test_timeseries.py
@@ -100,14 +100,18 @@ class TestDrawdown(TestCase):
     def test_drawdown_overlaps(self):
         # Add test to show that drawdowns don't overlap
         # Bug #145 observed for FB stock on the period 2014-10-24 - 2015-03-19
-        fb_rets = utils.get_symbol_rets('FB',
-                                        start="2014-10-15",
-                                        end="2015-04-01")
-        fb_drawdowns = timeseries.gen_drawdown_table(fb_rets, top=5).sort(
+        # Reproduced on SPY data (cached) but need a large number of drawdowns
+        spy_rets = utils.get_symbol_rets('SPY',
+                                         start='1997-01-01',
+                                         end='2004-12-31')
+        spy_drawdowns = timeseries.gen_drawdown_table(spy_rets, top=20).sort(
             'peak date')
-        pairs = list(zip(fb_drawdowns['recovery date'],
-                         fb_drawdowns['peak date'].shift(-1)))[:-1]
-        self.assertTrue(all(recovery <= peak for recovery, peak in pairs))
+        # Compare the recovery date of each drawdown with the peak of the next
+        # Last pair might contain a NaT if drawdown didn't finish, so ignore it
+        pairs = list(zip(spy_drawdowns['recovery date'],
+                         spy_drawdowns['peak date'].shift(-1)))[:-1]
+        for recovery, peak in pairs:
+            self.assertLessEqual(recovery, peak)
 
     @parameterized.expand([
         (pd.Series(px_list_1 - 1, index=dt), -0.44000000000000011)

--- a/pyfolio/tests/test_timeseries.py
+++ b/pyfolio/tests/test_timeseries.py
@@ -105,8 +105,8 @@ class TestDrawdown(TestCase):
                                         end="2015-04-01")
         fb_drawdowns = timeseries.gen_drawdown_table(fb_rets, top=5).sort(
             'peak date')
-        pairs = zip(fb_drawdowns['recovery date'],
-                    fb_drawdowns['peak date'].shift(-1))[:-1]
+        pairs = list(zip(fb_drawdowns['recovery date'],
+                    fb_drawdowns['peak date'].shift(-1)))[:-1]
         self.assertTrue(all(recovery <= peak for recovery, peak in pairs))
 
     @parameterized.expand([

--- a/pyfolio/tests/test_timeseries.py
+++ b/pyfolio/tests/test_timeseries.py
@@ -106,7 +106,7 @@ class TestDrawdown(TestCase):
         fb_drawdowns = timeseries.gen_drawdown_table(fb_rets, top=5).sort(
             'peak date')
         pairs = list(zip(fb_drawdowns['recovery date'],
-                    fb_drawdowns['peak date'].shift(-1)))[:-1]
+                         fb_drawdowns['peak date'].shift(-1)))[:-1]
         self.assertTrue(all(recovery <= peak for recovery, peak in pairs))
 
     @parameterized.expand([

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -767,7 +767,8 @@ def get_top_drawdowns(returns, top=10):
         peak, valley, recovery = get_max_drawdown_underwater(underwater)
         # Slice out draw-down period
         if not pd.isnull(recovery):
-            underwater.drop(underwater[peak: recovery].index[1:-1], inplace=True)
+            underwater.drop(underwater[peak: recovery].index[1:-1],
+                            inplace=True)
         else:
             # drawdown has not ended yet
             underwater = underwater.loc[:peak]


### PR DESCRIPTION
Fix the drawdown overlaps described in #145, also making the `get_drawdown` function more efficient.

Add a regression test that checks that the recovery of each drawdown occurs before the peak of the next (when ordered by date). 

Note: The test requires being online to pull the FB stock data (or have it cached). I couldn't find any guidelines about tests. If that is not appropriate let me know and I will work on getting an offline version of it.