### PR TITLE
Optionalize nb_tests for bayesian

### DIFF
--- a/pyfolio/tests/test_nbs.py
+++ b/pyfolio/tests/test_nbs.py
@@ -16,6 +16,14 @@ from pyfolio.utils import pyfolio_root
 def test_nbs():
     path = os.path.join(pyfolio_root(), 'examples', '*.ipynb')
     for ipynb in glob.glob(path):
+
+        # See if bayesian is useable before we run a test
+        if ipynb.endswith('bayesian.ipynb'):
+            try:
+                import pyfolio.bayesian  # NOQA
+            except:
+                continue
+
         with open(ipynb) as f:
             nb = read(f, 'json')
             nb_runner = NotebookRunner(nb)

--- a/pyfolio/tests/test_nbs.py
+++ b/pyfolio/tests/test_nbs.py
@@ -20,7 +20,7 @@ def test_nbs():
         # See if bayesian is useable before we run a test
         if ipynb.endswith('bayesian.ipynb'):
             try:
-                import pyfolio.bayesian  # NOQA
+                import pymc3  # NOQA
             except:
                 continue
 


### PR DESCRIPTION
We should not force tests on the Bayesian example NB because we do not require PyMC 3.

I'm not sure if there is a better way to check if the test can be run.

Closes #149.