### PR TITLE
Removed hardcoded business days per month. Only localize transactions.index if needed.

### DIFF
--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -503,11 +503,11 @@ def show_perf_stats(returns, factor_returns, live_start_date=None):
         perf_stats_all.loc['beta'] = perf_stats_all_ab[1]
         perf_stats_all.columns = ['All_History']
 
-        print('Out-of-Sample Months: ' + str(int(len(returns_live) / 21)))
+        print('Out-of-Sample Months: ' + str(int(len(returns_live) / APPROX_BDAYS_PER_MONTH)))
     else:
         returns_backtest = returns
 
-    print('Backtest Months: ' + str(int(len(returns_backtest) / 21)))
+    print('Backtest Months: ' + str(int(len(returns_backtest) / APPROX_BDAYS_PER_MONTH)))
 
     perf_stats = np.round(timeseries.perf_stats(
         returns_backtest, returns_style='arithmetic'), 2)

--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -503,11 +503,13 @@ def show_perf_stats(returns, factor_returns, live_start_date=None):
         perf_stats_all.loc['beta'] = perf_stats_all_ab[1]
         perf_stats_all.columns = ['All_History']
 
-        print('Out-of-Sample Months: ' + str(int(len(returns_live) / APPROX_BDAYS_PER_MONTH)))
+        print('Out-of-Sample Months: ' + \
+              str(int(len(returns_live) / APPROX_BDAYS_PER_MONTH)))
     else:
         returns_backtest = returns
 
-    print('Backtest Months: ' + str(int(len(returns_backtest) / APPROX_BDAYS_PER_MONTH)))
+    print('Backtest Months: ' + \
+          str(int(len(returns_backtest) / APPROX_BDAYS_PER_MONTH)))
 
     perf_stats = np.round(timeseries.perf_stats(
         returns_backtest, returns_style='arithmetic'), 2)

--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -503,12 +503,12 @@ def show_perf_stats(returns, factor_returns, live_start_date=None):
         perf_stats_all.loc['beta'] = perf_stats_all_ab[1]
         perf_stats_all.columns = ['All_History']
 
-        print('Out-of-Sample Months: ' + \
+        print('Out-of-Sample Months: ' +
               str(int(len(returns_live) / APPROX_BDAYS_PER_MONTH)))
     else:
         returns_backtest = returns
 
-    print('Backtest Months: ' + \
+    print('Backtest Months: ' +
           str(int(len(returns_backtest) / APPROX_BDAYS_PER_MONTH)))
 
     perf_stats = np.round(timeseries.perf_stats(
@@ -612,7 +612,8 @@ def plot_rolling_returns(
 
     if factor_returns is not None:
         timeseries.cum_returns(factor_returns[df_cum_rets.index], 1.0).plot(
-            lw=2, color='gray', label=factor_returns.name, alpha=0.60, ax=ax, **kwargs)
+            lw=2, color='gray', label=factor_returns.name, alpha=0.60,
+            ax=ax, **kwargs)
     if live_start_date is not None:
         live_start_date = utils.get_utc_timestamp(live_start_date)
 

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -772,6 +772,11 @@ def perf_stats(
     all_stats['max_drawdown'] = max_drawdown(returns)
     all_stats['omega_ratio'] = omega_ratio(returns)
     all_stats['sortino_ratio'] = sortino_ratio(returns)
+    # TODO: The information_ratio method requires
+    # a second argument for benchmark returns.
+    # Setting information_ratio to NaN until
+    # benchmark returns are added as an argument
+    # to this method.
     all_stats['information_ratio'] = np.nan
     all_stats['skewness'] = stats.skew(returns)
     all_stats['kurtosis'] = stats.kurtosis(returns)

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -772,14 +772,11 @@ def perf_stats(
     all_stats['max_drawdown'] = max_drawdown(returns)
     all_stats['omega_ratio'] = omega_ratio(returns)
     all_stats['sortino_ratio'] = sortino_ratio(returns)
-    
     # information_ratio needs a second argument for benchmark_returns
     #all_stats['information_ratio'] = information_ratio(returns)
     all_stats['information_ratio'] = np.nan
-    
     all_stats['skewness'] = stats.skew(returns)
     all_stats['kurtosis'] = stats.kurtosis(returns)
-
     if return_as_dict:
         return all_stats
     else:

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -772,8 +772,6 @@ def perf_stats(
     all_stats['max_drawdown'] = max_drawdown(returns)
     all_stats['omega_ratio'] = omega_ratio(returns)
     all_stats['sortino_ratio'] = sortino_ratio(returns)
-    # information_ratio needs a second argument for benchmark_returns
-    #all_stats['information_ratio'] = information_ratio(returns)
     all_stats['information_ratio'] = np.nan
     all_stats['skewness'] = stats.skew(returns)
     all_stats['kurtosis'] = stats.kurtosis(returns)

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -772,7 +772,11 @@ def perf_stats(
     all_stats['max_drawdown'] = max_drawdown(returns)
     all_stats['omega_ratio'] = omega_ratio(returns)
     all_stats['sortino_ratio'] = sortino_ratio(returns)
-    all_stats['information_ratio'] = information_ratio(returns)
+    
+    # information_ratio needs a second argument for benchmark_returns
+    #all_stats['information_ratio'] = information_ratio(returns)
+    all_stats['information_ratio'] = np.nan
+    
     all_stats['skewness'] = stats.skew(returns)
     all_stats['kurtosis'] = stats.kurtosis(returns)
 

--- a/pyfolio/utils.py
+++ b/pyfolio/utils.py
@@ -368,7 +368,9 @@ def extract_rets_pos_txn_from_zipline(backtest):
     positions = pos.extract_pos(positions, backtest.ending_cash)
     transactions_frame = txn.make_transaction_frame(backtest.transactions)
     transactions = txn.get_txn_vol(transactions_frame)
-    transactions.index = transactions.index.normalize().tz_localize('utc')
+    transactions.index = transactions.index.normalize()
+    if transactions.index.tzinfo is None:
+        transactions.index = transactions.index.tz_localize('utc')
 
     return returns, positions, transactions, gross_lev
 


### PR DESCRIPTION
I replaced the hard-coded 21 business days per month in the print statements `plotting.py` with the predefined constant for that value `utils.APPROX_BDAYS_PER_MONTH`.

I was also getting an error running the example notebook `zipline_algo_example.ipynb` with zipline 0.8.3. The index of the transactions DataFrame is trying to be localized to UTC but is already tz-aware:

```python
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-5-21b6f578f507> in <module>()
----> 1 returns, positions, transactions, gross_lev = pf.utils.extract_rets_pos_txn_from_zipline(backtest)

/home/pyfolio/pyfolio/utils.py in extract_rets_pos_txn_from_zipline(backtest)
    369     transactions_frame = txn.make_transaction_frame(backtest.transactions)
    370     transactions = txn.get_txn_vol(transactions_frame)
--> 371     transactions.index = transactions.index.normalize().tz_localize('utc')
    372 
    373     return returns, positions, transactions, gross_lev

/home/venv/local/lib/python2.7/site-packages/pandas/util/decorators.pyc in wrapper(*args, **kwargs)
     86                 else:
     87                     kwargs[new_arg_name] = new_arg_value
---> 88             return func(*args, **kwargs)
     89         return wrapper
     90     return _deprecate_kwarg

/home/venv/local/lib/python2.7/site-packages/pandas/tseries/index.pyc in tz_localize(self, tz, ambiguous)
   1638                 new_dates = tslib.tz_convert(self.asi8, 'UTC', self.tz)
   1639             else:
-> 1640                 raise TypeError("Already tz-aware, use tz_convert to convert.")
   1641         else:
   1642             tz = tslib.maybe_get_tz(tz)

TypeError: Already tz-aware, use tz_convert to convert.
```

I added a check that only does the localizing if the `tzinfo` is None.

Also, it seems that the `information_ratio` method as implemented in `timeseries.py` expects a second argument for benchmark_returns. However the call to `information_ratio` in `timeseries.perf_stats` only passes one argument. I just set information ratio to NaN for now, as there is no benchmark returns argument for `perf_stats`.