### PR TITLE
BUG use net liquidation value as the denominator in percent allocation calculation

### DIFF
--- a/pyfolio/pos.py
+++ b/pyfolio/pos.py
@@ -34,7 +34,7 @@ def get_percent_alloc(values):
         Positions and their allocations.
     """
     return values.divide(
-        values.abs().sum(axis='columns'),
+        values.sum(axis='columns'),
         axis='rows'
     )
 

--- a/pyfolio/pos.py
+++ b/pyfolio/pos.py
@@ -162,7 +162,7 @@ def get_sector_exposures(positions, symbol_sector_map):
     positions = positions.drop('cash', axis=1)
 
     unmapped_pos = np.setdiff1d(positions.columns.values,
-                                symbol_sector_map.keys())
+                                list(symbol_sector_map.keys()))
     if len(unmapped_pos) > 0:
         warn_message = """Warning: Symbols {} have no sector mapping.
         They will not be included in sector allocations""".format(

--- a/pyfolio/tests/test_pos.py
+++ b/pyfolio/tests/test_pos.py
@@ -11,7 +11,6 @@ from pandas import (
 from pandas.util.testing import (assert_frame_equal)
 
 from numpy import (
-    absolute,
     arange,
     zeros_like,
 )
@@ -40,7 +39,7 @@ class PositionsTestCase(TestCase):
         result = get_percent_alloc(frame)
         expected_raw = zeros_like(raw_data)
         for idx, row in enumerate(raw_data):
-            expected_raw[idx] = row / absolute(row).sum()
+            expected_raw[idx] = row / row.sum()
 
         expected = DataFrame(
             expected_raw,


### PR DESCRIPTION
Re: https://github.com/quantopian/pyfolio/issues/197
