### PR TITLE
ENH Replace linear cone with bootstrapped non-parametric cone

### DIFF
--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -560,11 +560,11 @@ def plot_rolling_returns(returns,
         benchmark returns. This helps compare strategies with different
         volatilities. Requires passing of benchmark_rets.
     cone_function : function, optional
-        Function to use when generating forecast probability cone. 
+        Function to use when generating forecast probability cone.
         The function signiture must follow the form:
-        def cone(in_sample_returns (pd.Series), 
+        def cone(in_sample_returns (pd.Series),
                  days_to_project_forward (int),
-                 cone_std= (float, or tuple), 
+                 cone_std= (float, or tuple),
                  starting_value= (int, or float))
         See timeseries.forecast_cone_bootstrap for an example.
     ax : matplotlib.Axes, optional

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -120,7 +120,7 @@ def create_full_tear_sheet(returns,
         - See txn.adjust_returns_for_slippage for more details.
     live_start_date : datetime, optional
         The point in time when the strategy began live trading,
-        after its backtest period.
+        after its backtest period. This datetime should be normalized.
     hide_positions : bool, optional
         If True, will not output any symbol names.
     bayesian: boolean, optional
@@ -275,6 +275,8 @@ def create_returns_tear_sheet(returns, live_start_date=None,
         live_start_date=live_start_date,
         cone_std=cone_std,
         ax=ax_rolling_returns)
+    ax_rolling_returns.set_title(
+        'Cumulative Returns')
 
     plotting.plot_rolling_returns(
         returns,
@@ -282,6 +284,7 @@ def create_returns_tear_sheet(returns, live_start_date=None,
         live_start_date=live_start_date,
         cone_std=None,
         volatility_match=True,
+        legend_loc=None,
         ax=ax_rolling_returns_vol_match)
     ax_rolling_returns_vol_match.set_title(
         'Cumulative returns volatility matched to benchmark.')

--- a/pyfolio/tests/test_timeseries.py
+++ b/pyfolio/tests/test_timeseries.py
@@ -370,7 +370,8 @@ class TestMultifactor(TestCase):
 
 class TestCone(TestCase):
     def test_bootstrap_cone_against_linear_cone_normal_returns(self):
-        np.random.seed(100)
+        random_seed = 100
+        np.random.seed(random_seed)
         days_forward = 20
         cone_stdevs = [1, 1.5, 2]
         mu = .005
@@ -387,7 +388,8 @@ class TestCone(TestCase):
 
         bootstrap_cone = timeseries.forecast_cone_bounds(rets, days_forward,
                                                          cone_stdevs,
-                                                         starting_value=1)
+                                                         starting_value=1,
+                                                         random_seed=random_seed)
         for col, vals in bootstrap_cone.iteritems():
             expected = normal_cone[col].values
             assert_allclose(vals.values, expected, rtol=.005)

--- a/pyfolio/tests/test_timeseries.py
+++ b/pyfolio/tests/test_timeseries.py
@@ -372,24 +372,24 @@ class TestCone(TestCase):
     def test_bootstrap_cone_against_linear_cone_normal_returns(self):
         random_seed = 100
         np.random.seed(random_seed)
-        days_forward = 20
+        days_forward = 200
         cone_stdevs = [1, 1.5, 2]
         mu = .005
         sigma = .002
-        rets = pd.Series(np.random.normal(mu, sigma, 1000))
+        rets = pd.Series(np.random.normal(mu, sigma, 10000))
 
         midline = np.cumprod(1 + (rets.mean() * np.ones(days_forward)))
-        stdev = rets.std() * np.sqrt(np.arange(days_forward)+1)
+        stdev = rets.std() * midline * np.sqrt(np.arange(days_forward)+1)
 
-        normal_cone = pd.DataFrame()
+        normal_cone = pd.DataFrame(columns=pd.Float64Index([]))
         for s in cone_stdevs:
-            normal_cone[str(s)] = midline + s * stdev
-            normal_cone[str(-s)] = midline - s * stdev
+            normal_cone[s] = midline + s * stdev
+            normal_cone[-s] = midline - s * stdev
 
-        bootstrap_cone = timeseries.forecast_cone_bounds(rets, days_forward,
-                                                         cone_stdevs,
-                                                         starting_value=1,
-                                                         random_seed=random_seed)
+        bootstrap_cone = timeseries.forecast_cone_bootstrap(
+            rets, days_forward, cone_stdevs, starting_value=1,
+            random_seed=random_seed, num_samples=10000)
+
         for col, vals in bootstrap_cone.iteritems():
             expected = normal_cone[col].values
             assert_allclose(vals.values, expected, rtol=.005)

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -985,129 +985,60 @@ def rolling_sharpe(returns, rolling_sharpe_window):
         * np.sqrt(APPROX_BDAYS_PER_YEAR)
 
 
-def cone_rolling(
-        input_rets,
-        num_stdev=1.0,
-        warm_up_days_pct=0.5,
-        std_scale_factor=APPROX_BDAYS_PER_YEAR,
-        update_std_oos_rolling=False,
-        cone_fit_end_date=None,
-        extend_fit_trend=True,
-        create_future_cone=True):
-    """Computes a rolling cone to place in the cumulative returns
-    plot. See plotting.plot_rolling_returns.
+def forecast_cone_bounds(is_returns, num_days, cone_std,
+                         starting_value=1, num_samples=1000):
     """
+    Determines the upper and lower bounds of an n standard deviation
+    cone of forecasted cumulative returns. Future cumulative mean and
+    standard devation are computed by repeatedly sampling from the
+    in-sample daily returns (i.e. bootstrap). This cone is non-parametric,
+    meaning it does not assume that returns are normally distributed.
 
-    # if specifying 'cone_fit_end_date' please use a pandas compatible format,
-    # e.g. '2015-8-4', 'YYYY-MM-DD'
+    Parameters
+    ----------
+    is_returns : pd.Series
+        In-sample daily returns of the strategy, noncumulative.
+         - See full explanation in tears.create_full_tear_sheet.
+    num_days : int
+        Number of days to project the probability cone forward.
+    cone_std : int, float, or list of int/float
+        Number of standard devations to use in the boundaries of
+        the cone. If multiple values are passed, cone bounds will
+        be generated for each value.
+    starting_value : int or float
+        Starting value of the out of sample period.
+    num_samples : int
+        Number of num_days length samples to draw from the in-sample
+        daily returns.
 
-    warm_up_days = int(warm_up_days_pct * input_rets.size)
+    Returns
+    -------
+    pd.DataFrame
+        Contains upper and lower cone boundaries. Column names are
+        strings corresponding to the number of standard devations
+        above (positive) or below (negative) the projected mean
+        cumulative returns.
+    """
+    np.random.seed(100)
+    samples = np.empty((num_samples, num_days))
 
-    # create initial linear fit from beginning of timeseries thru warm_up_days
-    # or the specified 'cone_fit_end_date'
-    if cone_fit_end_date is None:
-        returns = input_rets[:warm_up_days]
-    else:
-        returns = input_rets[input_rets.index < cone_fit_end_date]
+    for i in range(num_samples):
+        samples[i, :] = is_returns.sample(num_days, replace=True)
 
-    perf_ts = cum_returns(returns, 1)
+    cum_samples = np.cumprod(1 + samples, axis=1) * starting_value
 
-    X = list(range(0, perf_ts.size))
-    X = sm.add_constant(X)
-    sm.OLS(perf_ts, list(range(0, len(perf_ts))))
-    line_ols = sm.OLS(perf_ts.values, X).fit()
-    fit_line_ols_coef = line_ols.params[1]
-    fit_line_ols_inter = line_ols.params[0]
+    cum_mean = cum_samples.mean(axis=0)
+    cum_std = cum_samples.std(axis=0)
 
-    x_points = list(range(0, perf_ts.size))
-    x_points = np.array(x_points) * fit_line_ols_coef + fit_line_ols_inter
+    if isinstance(cone_std, (float, int)):
+        cone_std = [cone_std]
 
-    perf_ts_r = pd.DataFrame(perf_ts)
-    perf_ts_r.columns = ['perf']
+    cone_bounds = pd.DataFrame()
+    for num_std in cone_std:
+        cone_bounds[str(num_std)] = cum_mean + cum_std * num_std
+        cone_bounds[str(-num_std)] = cum_mean - cum_std * num_std
 
-    warm_up_std_pct = np.std(perf_ts.pct_change().dropna())
-    std_pct = warm_up_std_pct * np.sqrt(std_scale_factor)
-
-    perf_ts_r['line'] = x_points
-    perf_ts_r['sd_up'] = perf_ts_r['line'] * (1 + num_stdev * std_pct)
-    perf_ts_r['sd_down'] = perf_ts_r['line'] * (1 - num_stdev * std_pct)
-
-    std_pct = warm_up_std_pct * np.sqrt(std_scale_factor)
-
-    last_backtest_day_index = returns.index[-1]
-    cone_end_rets = input_rets[input_rets.index > last_backtest_day_index]
-    new_cone_day_scale_factor = int(1)
-    oos_intercept_shift = perf_ts_r.perf[-1] - perf_ts_r.line[-1]
-
-    # make the cone for the out-of-sample/live papertrading period
-    for i in cone_end_rets.index:
-        returns = input_rets[:i]
-        perf_ts = cum_returns(returns, 1)
-
-        if extend_fit_trend:
-            line_ols_coef = fit_line_ols_coef
-            line_ols_inter = fit_line_ols_inter
-        else:
-            X = list(range(0, perf_ts.size))
-            X = sm.add_constant(X)
-            sm.OLS(perf_ts, list(range(0, len(perf_ts))))
-            line_ols = sm.OLS(perf_ts.values, X).fit()
-            line_ols_coef = line_ols.params[1]
-            line_ols_inter = line_ols.params[0]
-
-        x_points = list(range(0, perf_ts.size))
-        x_points = np.array(x_points) * line_ols_coef + \
-            line_ols_inter + oos_intercept_shift
-
-        temp_line = x_points
-        if update_std_oos_rolling:
-            std_pct = np.sqrt(new_cone_day_scale_factor) * \
-                np.std(perf_ts.pct_change().dropna())
-        else:
-            std_pct = np.sqrt(new_cone_day_scale_factor) * warm_up_std_pct
-
-        temp_sd_up = temp_line * (1 + num_stdev * std_pct)
-        temp_sd_down = temp_line * (1 - num_stdev * std_pct)
-
-        new_daily_cone = pd.DataFrame(index=[i],
-                                      data={'perf': perf_ts[i],
-                                            'line': temp_line[-1],
-                                            'sd_up': temp_sd_up[-1],
-                                            'sd_down': temp_sd_down[-1]})
-
-        perf_ts_r = perf_ts_r.append(new_daily_cone)
-        new_cone_day_scale_factor += 1
-
-    if create_future_cone:
-        extend_ahead_days = APPROX_BDAYS_PER_YEAR
-        future_cone_dates = pd.date_range(
-            cone_end_rets.index[-1], periods=extend_ahead_days, freq='B')
-
-        future_cone_intercept_shift = perf_ts_r.perf[-1] - perf_ts_r.line[-1]
-
-        future_days_scale_factor = np.linspace(
-            1,
-            extend_ahead_days,
-            extend_ahead_days)
-        std_pct = np.sqrt(future_days_scale_factor) * warm_up_std_pct
-
-        x_points = list(range(perf_ts.size, perf_ts.size + extend_ahead_days))
-        x_points = np.array(x_points) * line_ols_coef + line_ols_inter + \
-            oos_intercept_shift + future_cone_intercept_shift
-        temp_line = x_points
-        temp_sd_up = temp_line * (1 + num_stdev * std_pct)
-        temp_sd_down = temp_line * (1 - num_stdev * std_pct)
-
-        future_cone = pd.DataFrame(index=list(map(np.datetime64,
-                                                  future_cone_dates)),
-                                   data={'perf': temp_line,
-                                         'line': temp_line,
-                                         'sd_up': temp_sd_up,
-                                         'sd_down': temp_sd_down})
-
-        perf_ts_r = perf_ts_r.append(future_cone)
-
-    return perf_ts_r
+    return cone_bounds
 
 
 def extract_interesting_date_ranges(returns):

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -1027,9 +1027,10 @@ def forecast_cone_bootstrap(is_returns, num_days, cone_std=[1, 1.5, 2],
     """
 
     samples = np.empty((num_samples, num_days))
+    seed = np.random.RandomState(seed=random_seed)
     for i in range(num_samples):
         samples[i, :] = is_returns.sample(num_days, replace=True,
-                                          random_state=random_seed)
+                                          random_state=seed)
 
     cum_samples = np.cumprod(1 + samples, axis=1) * starting_value
 


### PR DESCRIPTION
The old linear cone had several troubling assumptions (normal returns, use of arithmetic-like return averaging in the backtest, linearity of future returns, starting capital of oos == fixed starting value of the cone).

This new bootstrapped cone makes fewer assumptions by building its forward projection from samples drawn directly from the in-sample daily returns.  This direct sampling makes the bootstrapped cone non-parametric, it does not assume backtest returns fit into any particular distribution.

Discussion here: https://github.com/quantopian/pyfolio/issues/178