### PR TITLE
ENH: Suppress seaborn import warning

### DIFF
--- a/pyfolio/_seaborn.py
+++ b/pyfolio/_seaborn.py
@@ -1,0 +1,18 @@
+"""Wrapper module around seaborn to suppress warnings on import.
+
+This should be removed when seaborn stops raising:
+
+UserWarning: axes.color_cycle is deprecated and replaced with axes.prop_cycle;
+please use the latter.
+"""
+import warnings
+
+
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        'ignore',
+        'axes.color_cycle is deprecated',
+        UserWarning,
+        'matplotlib',
+    )
+    from seaborn import *  # noqa

--- a/pyfolio/bayesian.py
+++ b/pyfolio/bayesian.py
@@ -18,13 +18,13 @@ import numpy as np
 import pandas as pd
 import scipy as sp
 from scipy import stats
-import seaborn as sns
 import theano.tensor as tt
 
 import matplotlib.pyplot as plt
 
 import pymc3 as pm
 
+from . import _seaborn as sns
 from .timeseries import cum_returns
 
 

--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -18,7 +18,6 @@ import pandas as pd
 import numpy as np
 import scipy as sp
 
-import seaborn as sns
 import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.ticker import FuncFormatter
@@ -29,6 +28,7 @@ from sklearn import preprocessing
 from . import utils
 from . import timeseries
 from . import pos
+from . import _seaborn as sns
 from . import txn
 
 from .utils import APPROX_BDAYS_PER_MONTH

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -14,7 +14,14 @@
 # limitations under the License.
 from __future__ import division
 
+from time import time
 import warnings
+
+import matplotlib.pyplot as plt
+import matplotlib.gridspec as gridspec
+import numpy as np
+import scipy.stats
+import pandas as pd
 
 from . import timeseries
 from . import utils
@@ -22,6 +29,7 @@ from . import pos
 from . import txn
 from . import round_trips
 from . import plotting
+from . import _seaborn as sns
 from .plotting import plotting_context
 
 try:
@@ -30,15 +38,6 @@ except ImportError:
     warnings.warn(
         "Could not import bayesian submodule due to missing pymc3 dependency.",
         ImportWarning)
-
-import numpy as np
-import scipy.stats
-import pandas as pd
-
-import matplotlib.pyplot as plt
-import matplotlib.gridspec as gridspec
-import seaborn as sns
-from time import time
 
 
 def timer(msg_body, previous_time):


### PR DESCRIPTION
currently we raise a warning on import. This is actually coming out of matplotlib because of something in the import of seaborn
```python
In [1]: import pyfolio
/home/yui/.virtualenvs/pyfolio3/lib/python3.4/site-packages/matplotlib/__init__.py:872: UserWarning: axes.color_cycle is deprecated and replaced with axes.prop_cycle; please use the latter.
  warnings.warn(self.msg_depr % (key, alt_key))
```

This suppresses that warning because it is not directly our fault.