### PR TITLE
Refactor timeseries.py

### DIFF
--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import division
+from collections import OrderedDict
 
 import pandas as pd
 import numpy as np
@@ -510,13 +511,13 @@ def show_perf_stats(returns, factor_returns, live_start_date=None):
     perf_stats = np.round(timeseries.perf_stats(
         returns_backtest,
         factor_returns=factor_returns), 2)
-    perf_stats.columns = ['Backtest']
 
     if live_start_date is not None:
-        perf_stats = perf_stats.join(perf_stats_live,
-                                     how='inner')
-        perf_stats = perf_stats.join(perf_stats_all,
-                                     how='inner')
+        perf_stats = pd.DataFrame(OrderedDict([
+            ('Backtest', perf_stats),
+            ('Out of sample', perf_stats_live),
+            ('All history', perf_stats_all),
+        ]))
 
     print(perf_stats)
 

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -263,11 +263,6 @@ def create_returns_tear_sheet(returns, live_start_date=None,
     ax_monthly_dist = plt.subplot(gs[8, 2])
     ax_return_quantiles = plt.subplot(gs[9, :])
 
-    if live_start_date is not None:
-        ax_daily_similarity_scale = plt.subplot(gs[10, 0])
-        ax_daily_similarity_no_var = plt.subplot(gs[10, 1])
-        ax_daily_similarity_no_var_no_mean = plt.subplot(gs[10, 2])
-
     plotting.plot_rolling_returns(
         returns,
         factor_returns=benchmark_rets,
@@ -321,29 +316,6 @@ def create_returns_tear_sheet(returns, live_start_date=None,
         df_weekly,
         df_monthly,
         ax=ax_return_quantiles)
-
-    if live_start_date is not None:
-        returns_backtest = returns[returns.index < live_start_date]
-        returns_live = returns[returns.index > live_start_date]
-
-        plotting.plot_daily_returns_similarity(
-            returns_backtest,
-            returns_live,
-            title='Daily Returns Similarity',
-            ax=ax_daily_similarity_scale)
-        plotting.plot_daily_returns_similarity(
-            returns_backtest,
-            returns_live,
-            scale_kws={'with_std': False},
-            title='Similarity without\nvariance normalization',
-            ax=ax_daily_similarity_no_var)
-        plotting.plot_daily_returns_similarity(
-            returns_backtest,
-            returns_live,
-            scale_kws={'with_std': False,
-                       'with_mean': False},
-            title='Similarity without variance\nand mean normalization',
-            ax=ax_daily_similarity_no_var_no_mean)
 
     for ax in fig.axes:
         plt.setp(ax.get_xticklabels(), visible=True)

--- a/pyfolio/tests/test_timeseries.py
+++ b/pyfolio/tests/test_timeseries.py
@@ -289,7 +289,7 @@ class TestStats(TestCase):
             returns, rolling_sharpe_window).values.tolist()), expected)
 
     @parameterized.expand([
-        (simple_rets, 0.010766923838471554)
+        (simple_rets, 0.10376378866671222)
     ])
     def test_stability_of_timeseries(self, returns, expected):
         self.assertAlmostEqual(

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -21,15 +21,15 @@ import pandas as pd
 import numpy as np
 import scipy as sp
 import scipy.stats as stats
-from sklearn import preprocessing
-
-import statsmodels.api as sm
 
 from . import utils
 from .utils import APPROX_BDAYS_PER_MONTH, APPROX_BDAYS_PER_YEAR
 from .utils import DAILY, WEEKLY, MONTHLY, YEARLY, ANNUALIZATION_FACTORS
 from .interesting_periods import PERIODS
 
+
+#####################################
+# Risk metrics
 
 def var_cov_var_normal(P, c, mu=0, sigma=1):
     """Variance-covariance calculation of daily Value-at-Risk in a
@@ -53,104 +53,6 @@ def var_cov_var_normal(P, c, mu=0, sigma=1):
 
     alpha = sp.stats.norm.ppf(1 - c, mu, sigma)
     return P - P * (alpha + 1)
-
-
-def normalize(returns, starting_value=1):
-    """
-    Normalizes a returns timeseries based on the first value.
-
-    Parameters
-    ----------
-    returns : pd.Series
-        Daily returns of the strategy, noncumulative.
-         - See full explanation in tears.create_full_tear_sheet.
-    starting_value : float, optional
-       The starting returns (default 1).
-
-    Returns
-    -------
-    pd.Series
-        Normalized returns.
-    """
-
-    return starting_value * (returns / returns.iloc[0])
-
-
-def cum_returns(returns, starting_value=None):
-    """
-    Compute cumulative returns from simple returns.
-
-    Parameters
-    ----------
-    returns : pd.Series
-        Daily returns of the strategy, noncumulative.
-         - See full explanation in tears.create_full_tear_sheet.
-    starting_value : float, optional
-       The starting returns (default 1).
-
-    Returns
-    -------
-    pandas.Series
-        Series of cumulative returns.
-
-    Notes
-    -----
-    For increased numerical accuracy, convert input to log returns
-    where it is possible to sum instead of multiplying.
-    """
-
-    # df_price.pct_change() adds a nan in first position, we can use
-    # that to have cum_returns start at the origin so that
-    # df_cum.iloc[0] == starting_value
-    # Note that we can't add that ourselves as we don't know which dt
-    # to use.
-    if pd.isnull(returns.iloc[0]):
-        returns.iloc[0] = 0.
-
-    df_cum = np.exp(np.log(1 + returns).cumsum())
-
-    if starting_value is None:
-        return df_cum - 1
-    else:
-        return df_cum * starting_value
-
-
-def aggregate_returns(df_daily_rets, convert_to):
-    """
-    Aggregates returns by week, month, or year.
-
-    Parameters
-    ----------
-    df_daily_rets : pd.Series
-       Daily returns of the strategy, noncumulative.
-        - See full explanation in tears.create_full_tear_sheet (returns).
-    convert_to : str
-        Can be 'weekly', 'monthly', or 'yearly'.
-
-    Returns
-    -------
-    pd.Series
-        Aggregated returns.
-    """
-
-    def cumulate_returns(x):
-        return cum_returns(x)[-1]
-
-    if convert_to == WEEKLY:
-        return df_daily_rets.groupby(
-            [lambda x: x.year,
-             lambda x: x.month,
-             lambda x: x.isocalendar()[1]]).apply(cumulate_returns)
-    elif convert_to == MONTHLY:
-        return df_daily_rets.groupby(
-            [lambda x: x.year, lambda x: x.month]).apply(cumulate_returns)
-    elif convert_to == YEARLY:
-        return df_daily_rets.groupby(
-            [lambda x: x.year]).apply(cumulate_returns)
-    else:
-        ValueError(
-            'convert_to must be {}, {} or {}'.format(WEEKLY, MONTHLY, YEARLY)
-        )
 
 
 def max_drawdown(returns):
@@ -472,114 +374,223 @@ def sharpe_ratio(returns, risk_free=0, period=DAILY):
         np.sqrt(ANNUALIZATION_FACTORS[period])
 
 
-def stability_of_timeseries(returns):
-    """Determines R-squared of a linear fit to the returns.
+def information_ratio(returns, factor_returns):
+    """
+    Determines the Information ratio of a strategy.
 
-    Computes an ordinary least squares linear fit, and returns
-    R-squared.
+    Parameters
+    ----------
+    returns : pd.Series or pd.DataFrame
+        Daily returns of the strategy, noncumulative.
+         - See full explanation in tears.create_full_tear_sheet.
+    factor_returns: float / series
+
+    Returns
+    -------
+    float
+        The information ratio.
+
+    Note
+    -----
+    See https://en.wikipedia.org/wiki/information_ratio for more details.
+
+    """
+    active_return = returns - factor_returns
+    tracking_error = np.std(active_return, ddof=1)
+    if np.isnan(tracking_error):
+        return 0.0
+    return np.mean(active_return) / tracking_error
+
+
+def alpha_beta(returns, factor_returns):
+    """Calculates both alpha and beta.
 
     Parameters
     ----------
     returns : pd.Series
         Daily returns of the strategy, noncumulative.
          - See full explanation in tears.create_full_tear_sheet.
+    factor_returns : pd.Series
+         Daily noncumulative returns of the factor to which beta is
+         computed. Usually a benchmark such as the market.
+         - This is in the same style as returns.
 
     Returns
     -------
     float
-        R-squared.
+        Alpha.
+    float
+        Beta.
 
-    """
+"""
 
-    if returns.size < 2:
-        return np.nan
+    ret_index = returns.index
+    beta, alpha = sp.stats.linregress(factor_returns.loc[ret_index].values,
+                                      returns.values)[:2]
 
-    df_cum_rets = cum_returns(returns, starting_value=100)
-    df_cum_rets_log = np.log10(df_cum_rets.values)
-    len_returns = df_cum_rets.size
-
-    X = list(range(0, len_returns))
-    X = sm.add_constant(X)
-
-    model = sm.OLS(df_cum_rets_log, X).fit()
-
-    return model.rsquared
+    return alpha * APPROX_BDAYS_PER_YEAR, beta
 
 
-def out_of_sample_vs_in_sample_returns_kde(
-        bt_ts, oos_ts, transform_style='scale', return_zero_if_exception=True):
-    """Determines similarity between two returns timeseries.
-
-    Typically a backtest frame (in-sample) and live frame
-    (out-of-sample).
+def alpha(returns, factor_returns):
+    """Calculates annualized alpha.
 
     Parameters
     ----------
-    bt_ts : pd.Series
-       In-sample (backtest) returns of the strategy, noncumulative.
-        - See full explanation in tears.create_full_tear_sheet (returns).
-    oos_ts : pd.Series
-       Out-of-sample (live trading) returns of the strategy,
-       noncumulative.
-        - See full explanation in tears.create_full_tear_sheet (returns).
-    transform_style : float, optional
-        'raw', 'scale', 'Normalize_L1', 'Normalize_L2' (default
-        'scale')
-    return_zero_if_exception : bool, optional
-        If there is an exception, return zero instead of NaN.
+    returns : pd.Series
+        Daily returns of the strategy, noncumulative.
+         - See full explanation in tears.create_full_tear_sheet.
+    factor_returns : pd.Series
+         Daily noncumulative returns of the factor to which beta is
+         computed. Usually a benchmark such as the market.
+         - This is in the same style as returns.
 
     Returns
     -------
     float
-        Similarity between returns.
+        Alpha.
+"""
 
+    return alpha_beta(returns, factor_returns)[0]
+
+
+def beta(returns, factor_returns):
+    """Calculates beta.
+
+    Parameters
+    ----------
+    returns : pd.Series
+        Daily returns of the strategy, noncumulative.
+         - See full explanation in tears.create_full_tear_sheet.
+    factor_returns : pd.Series
+         Daily noncumulative returns of the factor to which beta is
+         computed. Usually a benchmark such as the market.
+         - This is in the same style as returns.
+
+    Returns
+    -------
+    float
+        Beta.
+"""
+
+    return alpha_beta(returns, factor_returns)[1]
+
+
+SIMPLE_STAT_FUNCS = [
+    annual_return,
+    annual_volatility,
+    sharpe_ratio,
+    calmar_ratio,
+    stability_of_timeseries,
+    max_drawdown,
+    omega_ratio,
+    sortino_ratio,
+    stats.skew,
+    stats.kurtosis,
+]
+
+FACTOR_STAT_FUNCS = [
+    information_ratio,
+    alpha,
+    beta,
+]
+
+
+def normalize(returns, starting_value=1):
+    """
+    Normalizes a returns timeseries based on the first value.
+
+    Parameters
+    ----------
+    returns : pd.Series
+        Daily returns of the strategy, noncumulative.
+         - See full explanation in tears.create_full_tear_sheet.
+    starting_value : float, optional
+       The starting returns (default 1).
+
+    Returns
+    -------
+    pd.Series
+        Normalized returns.
     """
 
-    bt_ts_pct = bt_ts.dropna()
-    oos_ts_pct = oos_ts.dropna()
+    return starting_value * (returns / returns.iloc[0])
 
-    bt_ts_r = bt_ts_pct.reshape(len(bt_ts_pct), 1)
-    oos_ts_r = oos_ts_pct.reshape(len(oos_ts_pct), 1)
 
-    if transform_style == 'raw':
-        bt_scaled = bt_ts_r
-        oos_scaled = oos_ts_r
-    if transform_style == 'scale':
-        bt_scaled = preprocessing.scale(bt_ts_r, axis=0)
-        oos_scaled = preprocessing.scale(oos_ts_r, axis=0)
-    if transform_style == 'normalize_L2':
-        bt_scaled = preprocessing.normalize(bt_ts_r, axis=1)
-        oos_scaled = preprocessing.normalize(oos_ts_r, axis=1)
-    if transform_style == 'normalize_L1':
-        bt_scaled = preprocessing.normalize(bt_ts_r, axis=1, norm='l1')
-        oos_scaled = preprocessing.normalize(oos_ts_r, axis=1, norm='l1')
+def cum_returns(returns, starting_value=None):
+    """
+    Compute cumulative returns from simple returns.
 
-    X_train = bt_scaled
-    X_test = oos_scaled
+    Parameters
+    ----------
+    returns : pd.Series
+        Daily returns of the strategy, noncumulative.
+         - See full explanation in tears.create_full_tear_sheet.
+    starting_value : float, optional
+       The starting returns (default 1).
 
-    X_train = X_train.reshape(len(X_train))
-    X_test = X_test.reshape(len(X_test))
+    Returns
+    -------
+    pandas.Series
+        Series of cumulative returns.
 
-    x_axis_dim = np.linspace(-4, 4, 100)
-    kernal_method = 'scott'
+    Notes
+    -----
+    For increased numerical accuracy, convert input to log returns
+    where it is possible to sum instead of multiplying.
+    """
 
-    try:
-        scipy_kde_train = stats.gaussian_kde(
-            X_train,
-            bw_method=kernal_method)(x_axis_dim)
-        scipy_kde_test = stats.gaussian_kde(
-            X_test,
-            bw_method=kernal_method)(x_axis_dim)
-    except:
-        if return_zero_if_exception:
-            return 0.0
-        else:
-            return np.nan
+    # df_price.pct_change() adds a nan in first position, we can use
+    # that to have cum_returns start at the origin so that
+    # df_cum.iloc[0] == starting_value
+    # Note that we can't add that ourselves as we don't know which dt
+    # to use.
+    if pd.isnull(returns.iloc[0]):
+        returns.iloc[0] = 0.
 
-    kde_diff = sum(abs(scipy_kde_test - scipy_kde_train)) / \
-        (sum(scipy_kde_train) + sum(scipy_kde_test))
+    df_cum = np.exp(np.log(1 + returns).cumsum())
 
-    return kde_diff
+    if starting_value is None:
+        return df_cum - 1
+    else:
+        return df_cum * starting_value
+
+
+def aggregate_returns(df_daily_rets, convert_to):
+    """
+    Aggregates returns by week, month, or year.
+
+    Parameters
+    ----------
+    df_daily_rets : pd.Series
+       Daily returns of the strategy, noncumulative.
+        - See full explanation in tears.create_full_tear_sheet (returns).
+    convert_to : str
+        Can be 'weekly', 'monthly', or 'yearly'.
+
+    Returns
+    -------
+    pd.Series
+        Aggregated returns.
+    """
+
+    def cumulate_returns(x):
+        return cum_returns(x)[-1]
+
+    if convert_to == WEEKLY:
+        return df_daily_rets.groupby(
+            [lambda x: x.year,
+             lambda x: x.month,
+             lambda x: x.isocalendar()[1]]).apply(cumulate_returns)
+    elif convert_to == MONTHLY:
+        return df_daily_rets.groupby(
+            [lambda x: x.year, lambda x: x.month]).apply(cumulate_returns)
+    elif convert_to == YEARLY:
+        return df_daily_rets.groupby(
+            [lambda x: x.year]).apply(cumulate_returns)
+    else:
+        ValueError(
+            'convert_to must be {}, {} or {}'.format(WEEKLY, MONTHLY, YEARLY)
+        )
 
 
 def calc_multifactor(returns, factors):
@@ -1059,229 +1070,3 @@ def extract_interesting_date_ranges(returns):
             continue
 
     return ranges
-
-
-def portfolio_returns(holdings_returns, exclude_non_overlapping=True):
-    """Generates an equal-weight portfolio.
-
-    Parameters
-    ----------
-    holdings_returns : list
-       List containing each individual holding's daily returns of the
-       strategy, noncumulative.
-
-    exclude_non_overlapping : boolean, optional
-       If True, timeseries returned will include values only for dates
-       available across all holdings_returns timeseries If False, 0%
-       returns will be assumed for a holding until it has valid data
-
-    Returns
-    -------
-    pd.Series
-        Equal-weight returns timeseries.
-    """
-    port = holdings_returns[0]
-    for i in range(1, len(holdings_returns)):
-        port = port + holdings_returns[i]
-
-    if exclude_non_overlapping:
-        port = port.dropna()
-    else:
-        port = port.fillna(0)
-
-    return port / len(holdings_returns)
-
-
-def portfolio_returns_metric_weighted(holdings_returns,
-                                      exclude_non_overlapping=True,
-                                      weight_function=None,
-                                      weight_function_window=None,
-                                      inverse_weight=False,
-                                      portfolio_rebalance_rule='q',
-                                      weight_func_transform=None):
-    """
-    Generates an equal-weight portfolio, or portfolio weighted by
-    weight_function
-
-    Parameters
-    ----------
-    holdings_returns : list
-       List containing each individual holding's daily returns of the
-       strategy, noncumulative.
-
-    exclude_non_overlapping : boolean, optional
-       (Only applicable if equal-weight portfolio, e.g. weight_function=None)
-       If True, timeseries returned will include values only for dates
-       available across all holdings_returns timeseries If False, 0%
-       returns will be assumed for a holding until it has valid data
-
-    weight_function : function, optional
-       Function to be applied to holdings_returns timeseries
-
-    weight_function_window : int, optional
-       Rolling window over which weight_function will use as its input values
-
-    inverse_weight : boolean, optional
-       If True, high values returned from weight_function will result in lower
-       weight for that holding
-
-    portfolio_rebalance_rule : string, optional
-       A pandas.resample valid rule. Specifies how frequently to compute
-       the weighting criteria
-
-    weight_func_transform : function, optional
-       Function applied to value returned from weight_function
-
-    Returns
-    -------
-    (pd.Series, pd.DataFrame)
-        pd.Series : Portfolio returns timeseries.
-        pd.DataFrame : All the raw data used in the portfolio returns
-           calculations
-    """
-
-    if weight_function is None:
-        if exclude_non_overlapping:
-            holdings_df = pd.DataFrame(holdings_returns).T.dropna()
-        else:
-            holdings_df = pd.DataFrame(holdings_returns).T.fillna(0)
-
-        holdings_df['port_ret'] = holdings_df.sum(
-            axis=1) / len(holdings_returns)
-    else:
-        holdings_df_na = pd.DataFrame(holdings_returns).T
-        holdings_cols = holdings_df_na.columns
-        holdings_df = holdings_df_na.dropna()
-        holdings_func = pd.rolling_apply(holdings_df,
-                                         window=weight_function_window,
-                                         func=weight_function).dropna()
-        holdings_func_rebal = holdings_func.resample(
-            rule=portfolio_rebalance_rule,
-            how='last')
-        holdings_df = holdings_df.join(
-            holdings_func_rebal, rsuffix='_f').fillna(method='ffill').dropna()
-        if weight_func_transform is None:
-            holdings_func_rebal_t = holdings_func_rebal
-            holdings_df = holdings_df.join(
-                holdings_func_rebal_t,
-                rsuffix='_t').fillna(method='ffill').dropna()
-        else:
-            holdings_func_rebal_t = holdings_func_rebal.applymap(
-                weight_func_transform)
-            holdings_df = holdings_df.join(
-                holdings_func_rebal_t,
-                rsuffix='_t').fillna(method='ffill').dropna()
-        transform_columns = list(map(lambda x: x + "_t", holdings_cols))
-        if inverse_weight:
-            inv_func = 1.0 / holdings_df[transform_columns]
-            holdings_df_weights = inv_func.div(inv_func.sum(axis=1),
-                                               axis='index')
-        else:
-            holdings_df_weights = holdings_df[transform_columns] \
-                .div(holdings_df[transform_columns].sum(axis=1), axis='index')
-
-        holdings_df_weights.columns = holdings_cols
-        holdings_df = holdings_df.join(holdings_df_weights, rsuffix='_w')
-        holdings_df_weighted_rets = np.multiply(
-            holdings_df[holdings_cols], holdings_df_weights)
-        holdings_df_weighted_rets['port_ret'] = holdings_df_weighted_rets.sum(
-            axis=1)
-        holdings_df = holdings_df.join(holdings_df_weighted_rets,
-                                       rsuffix='_wret')
-
-    return holdings_df['port_ret'], holdings_df
-
-
-def bucket_std(value, bins=[0.12, 0.15, 0.18, 0.21], max_default=0.24):
-    """
-    Simple quantizing function. For use in binning stdevs into a "buckets"
-
-    Parameters
-    ----------
-    value : float
-       Value corresponding to the the stdev to be bucketed
-
-    bins : list, optional
-       Floats used to describe the buckets which the value can be placed
-
-    max_default : float, optional
-       If value is greater than all the bins, max_default will be returned
-
-    Returns
-    -------
-    float
-        bin which the value falls into
-    """
-
-    annual_vol = value * np.sqrt(252)
-
-    for i in bins:
-        if annual_vol <= i:
-            return i
-
-    return max_default
-
-
-def min_max_vol_bounds(value, lower_bound=0.12, upper_bound=0.24):
-    """
-    Restrict volatility weighting of the lowest volatility asset versus the
-    highest volatility asset to a certain limit.
-    E.g. Never allocate more than 2x to the lowest volatility asset.
-    round up all the asset volatilities that fall below a certain bound
-    to a specified "lower bound" and round down all of the asset
-    volatilites that fall above a certain bound to a specified "upper bound"
-
-    Parameters
-    ----------
-    value : float
-       Value corresponding to a daily volatility
-
-    lower_bound : float, optional
-       Lower bound for the volatility
-
-    upper_bound : float, optional
-       Upper bound for the volatility
-
-    Returns
-    -------
-    float
-        The value input, annualized, or the lower_bound or upper_bound
-    """
-
-    annual_vol = value * np.sqrt(252)
-
-    if annual_vol < lower_bound:
-        return lower_bound
-
-    if annual_vol > upper_bound:
-        return upper_bound
-
-    return annual_vol
-
-
-def information_ratio(returns, factor_returns):
-    """
-    Determines the Information ratio of a strategy.
-
-    Parameters
-    ----------
-    returns : pd.Series or pd.DataFrame
-        Daily returns of the strategy, noncumulative.
-         - See full explanation in tears.create_full_tear_sheet.
-    factor_returns: float / series
-
-    Returns
-    -------
-    float
-        The information ratio.
-
-    Note
-    -----
-    See https://en.wikipedia.org/wiki/information_ratio for more details.
-
-    """
-    active_return = returns - factor_returns
-    tracking_error = np.std(active_return, ddof=1)
-    if np.isnan(tracking_error):
-        return 0.0
-    return np.mean(active_return) / tracking_error

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -490,7 +490,7 @@ def stability_of_timeseries(returns):
 
     """
 
-    cum_log_returns = np.log(1 + returns).cumsum()
+    cum_log_returns = np.log1p(returns).cumsum()
     rhat = stats.linregress(np.arange(len(cum_log_returns)),
                             cum_log_returns.values)[2]
 

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -601,7 +601,6 @@ def aggregate_returns(df_daily_rets, convert_to):
     if convert_to == WEEKLY:
         return df_daily_rets.groupby(
             [lambda x: x.year,
-             lambda x: x.month,
              lambda x: x.isocalendar()[1]]).apply(cumulate_returns)
     elif convert_to == MONTHLY:
         return df_daily_rets.groupby(

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -731,6 +731,7 @@ def perf_stats(returns, factor_returns=None):
 
     return stats
 
+
 def get_max_drawdown_underwater(underwater):
     """Determines peak, valley, and recovery dates given and 'underwater'
     DataFrame.

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -28,9 +28,6 @@ from .utils import DAILY, WEEKLY, MONTHLY, YEARLY, ANNUALIZATION_FACTORS
 from .interesting_periods import PERIODS
 
 
-#####################################
-# Risk metrics
-
 def var_cov_var_normal(P, c, mu=0, sigma=1):
     """Variance-covariance calculation of daily Value-at-Risk in a
     portfolio.

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -474,6 +474,7 @@ def beta(returns, factor_returns):
 
     return alpha_beta(returns, factor_returns)[1]
 
+
 def stability_of_timeseries(returns):
     """Determines R-squared of a linear fit to the cumulative
     log returns. Computes an ordinary least squares linear fit,
@@ -680,7 +681,7 @@ def rolling_beta(returns, factor_returns,
         out = pd.Series(index=returns.index)
         for beg, end in zip(returns.index[0:-rolling_window],
                             returns.index[rolling_window:]):
-            out.loc[end] = calc_alpha_beta(
+            out.loc[end] = alpha_beta(
                 returns.loc[beg:end],
                 factor_returns.loc[beg:end])[1]
 
@@ -744,12 +745,11 @@ def perf_stats(returns, factor_returns=None):
 
     stats = pd.Series()
 
-    for stat_func in simple_stat_funcs:
+    for stat_func in SIMPLE_STAT_FUNCS:
         stats[stat_func.__name__] = stat_func(returns)
 
     if factor_returns is not None:
-        for stat_func in factor_stat_funcs:
-            stat_name = stat_func.__name__
+        for stat_func in FACTOR_STAT_FUNCS:
             stats[stat_func.__name__] = stat_func(returns,
                                                   factor_returns)
 

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -474,6 +474,30 @@ def beta(returns, factor_returns):
 
     return alpha_beta(returns, factor_returns)[1]
 
+def stability_of_timeseries(returns):
+    """Determines R-squared of a linear fit to the cumulative
+    log returns. Computes an ordinary least squares linear fit,
+    and returns R-squared.
+
+    Parameters
+    ----------
+    returns : pd.Series
+        Daily returns of the strategy, noncumulative.
+         - See full explanation in tears.create_full_tear_sheet.
+
+    Returns
+    -------
+    float
+        R-squared.
+
+    """
+
+    cum_log_returns = np.log(1 + returns).cumsum()
+    rhat = stats.linregress(np.arange(len(cum_log_returns)),
+                            cum_log_returns.values)[2]
+
+    return rhat
+
 
 SIMPLE_STAT_FUNCS = [
     annual_return,

--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,8 @@ install_reqs = [
     'pyparsing>=2.0.3',
     'python-dateutil>=2.4.2',
     'pytz>=2014.10',
-    'scikit-learn>=0.15.0',
     'scipy>=0.14.0',
     'seaborn>=0.6.0',
-    'statsmodels>=0.5.0',
     'pandas-datareader>=0.2',
 ]
 


### PR DESCRIPTION
Quite a large refactoring. 

* Put risk metrics to beginning of timeseries.py (unfortunately this, and the remove of old code mess up the diff).
* Add list of all risk metrics that can be computed just on returns and those which require factor returns.
* Removal of portfolio code that I think should go somewhere else and did not look like production code.
* Deprecate `out_of_sample_vs_in_sample_returns_kde()` and `stability_of_timeseries()`.
* Remove statsmodels and scikits-learn dependencies. Closes #232.

These changes are required for #261.

CC @llllllllll, @a-campbell, @justinlent 