### PR TITLE
Correct volatility match in plot_rolling_returns

### DIFF
--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -632,7 +632,7 @@ def plot_rolling_returns(returns,
                          'factor_returns.')
     elif volatility_match and factor_returns is not None:
         bmark_vol = factor_returns.loc[returns.index].std()
-        returns = (returns / returns.std()) * bmark_vol
+        returns = returns * (returns.std() / bmark_vol)
 
     cum_rets = timeseries.cum_returns(returns, 1.0)
 


### PR DESCRIPTION
Correct formula to calculate returns vs benchmark from:

```
returns = (returns / returns.std()) * bmark_vol
```

To:

```
returns = returns * (returns.std() / bmark_vol)
```

This will make a proper comparison of stock returns vs benchmark:

```
import pyfolio as pf
stock_rets = pf.utils.get_symbol_rets('FB')
bench_rets = pf.utils.get_symbol_rets('SPY')
```

Returns as they are:

```
pf.plotting.plot_rolling_returns(stock_rets, 
                                 factor_returns=bench_rets, 
                                 volatility_match=False)
```

![ret1](https://cloud.githubusercontent.com/assets/5990528/13535997/56d0e62a-e24e-11e5-962f-ae783778ecd2.png)

Matched returns with original formula don't reflect the real dynamic (i.e `FB` doesn't cross `SPY`):

```
# returns = (returns / returns.std()) * bmark_vol                                 
pf.plotting.plot_rolling_returns(stock_rets, 
                                 factor_returns=bench_rets, 
                                 volatility_match=True)                                 
```

![ret2](https://cloud.githubusercontent.com/assets/5990528/13536123/34ce38a6-e24f-11e5-8337-73faa9756802.png)

Matched returns with proposed formula has the same denominator as benchmark and therefore is relationship between the lines is not distorted:

```
# returns = returns * (returns.std() / bmark_vol)
pf.plotting.plot_rolling_returns(stock_rets, 
                                 factor_returns=bench_rets, 
                                 volatility_match=True)
```

![ret3](https://cloud.githubusercontent.com/assets/5990528/13536160/6f20cb86-e24f-11e5-9620-75970b2c5d40.png)
