### PR TITLE
Add qrisk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
 install:
   - conda create -q -n testenv --yes python=$TRAVIS_PYTHON_VERSION ipython pyzmq numpy scipy nose matplotlib pandas Cython patsy statsmodels flake8 scikit-learn seaborn runipy pytables networkx pandas-datareader matplotlib-tests joblib
   - source activate testenv
-  - pip install nose_parameterized contextlib2 logbook==0.10.1
+  - pip install nose_parameterized contextlib2 logbook==0.10.1 qrisk
   #- pip install --no-deps git+https://github.com/quantopian/zipline
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then conda install --yes mock enum34; fi
   - pip install --no-deps git+https://github.com/Theano/Theano.git@rel-0.8.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
 install:
   - conda create -q -n testenv --yes python=$TRAVIS_PYTHON_VERSION ipython pyzmq numpy scipy nose matplotlib pandas Cython patsy statsmodels flake8 scikit-learn seaborn runipy pytables networkx pandas-datareader matplotlib-tests joblib
   - source activate testenv
-  - pip install nose_parameterized
+  - pip install nose_parameterized qrisk>=0.1.4
   #- pip install --no-deps git+https://github.com/quantopian/zipline
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then conda install --yes mock enum34; fi
   - pip install --no-deps git+https://github.com/Theano/Theano.git@rel-0.8.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
 install:
   - conda create -q -n testenv --yes python=$TRAVIS_PYTHON_VERSION ipython pyzmq numpy scipy nose matplotlib pandas Cython patsy statsmodels flake8 scikit-learn seaborn runipy pytables networkx pandas-datareader matplotlib-tests joblib
   - source activate testenv
-  - pip install nose_parameterized contextlib2 logbook==0.10.1 qrisk>=0.1.3
+  - pip install nose_parameterized
   #- pip install --no-deps git+https://github.com/quantopian/zipline
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then conda install --yes mock enum34; fi
   - pip install --no-deps git+https://github.com/Theano/Theano.git@rel-0.8.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
 install:
   - conda create -q -n testenv --yes python=$TRAVIS_PYTHON_VERSION ipython pyzmq numpy scipy nose matplotlib pandas Cython patsy statsmodels flake8 scikit-learn seaborn runipy pytables networkx pandas-datareader matplotlib-tests joblib
   - source activate testenv
-  - pip install nose_parameterized contextlib2 logbook==0.10.1 qrisk
+  - pip install nose_parameterized contextlib2 logbook==0.10.1 qrisk>=0.1.3
   #- pip install --no-deps git+https://github.com/quantopian/zipline
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then conda install --yes mock enum34; fi
   - pip install --no-deps git+https://github.com/Theano/Theano.git@rel-0.8.1

--- a/pyfolio/bayesian.py
+++ b/pyfolio/bayesian.py
@@ -30,7 +30,7 @@ except ImportError:
     from pymc3 import T as StudentT
 
 from . import _seaborn as sns
-from .timeseries import cum_returns
+from qrisk import cum_returns
 
 
 def model_returns_t_alpha_beta(data, bmark, samples=2000):

--- a/pyfolio/capacity.py
+++ b/pyfolio/capacity.py
@@ -2,7 +2,7 @@ from __future__ import division
 import pandas as pd
 import numpy as np
 from . import pos
-from . import timeseries
+import qrisk
 
 
 def daily_txns_with_bar_data(transactions, market_data):
@@ -233,7 +233,7 @@ def apply_slippage_penalty(returns, txn_daily, simulate_starting_capital,
     # by capital base, it makes the most sense to scale the denominator
     # similarly. In other words, since we aren't applying compounding to
     # simulate_traded_shares, we shouldn't apply compounding to pv.
-    portfolio_value = timeseries.cum_returns(
+    portfolio_value = qrisk.cum_returns(
         returns, starting_value=backtest_starting_capital) * mult
 
     adj_returns = returns - (daily_penalty / portfolio_value)

--- a/pyfolio/deprecate.py
+++ b/pyfolio/deprecate.py
@@ -1,0 +1,45 @@
+"""Utilities for marking deprecated functions."""
+# Copyright 2016 Quantopian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+from functools import wraps
+
+
+def deprecated(msg=None, stacklevel=2):
+    """
+    Used to mark a function as deprecated.
+    Parameters
+    ----------
+    msg : str
+        The message to display in the deprecation warning.
+    stacklevel : int
+        How far up the stack the warning needs to go, before
+        showing the relevant calling lines.
+    Usage
+    -----
+    @deprecated(msg='function_a is deprecated! Use function_b instead.')
+    def function_a(*args, **kwargs):
+    """
+    def deprecated_dec(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            warnings.warn(
+                msg or "Function %s is deprecated." % fn.__name__,
+                category=DeprecationWarning,
+                stacklevel=stacklevel
+            )
+            return fn(*args, **kwargs)
+        return wrapper
+    return deprecated_dec

--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -194,8 +194,7 @@ def plot_monthly_returns_heatmap(returns, ax=None, **kwargs):
     if ax is None:
         ax = plt.gca()
 
-    monthly_ret_table = timeseries.aggregate_returns(returns,
-                                                     'monthly')
+    monthly_ret_table = qrisk.aggregate_returns(returns, 'monthly')
     monthly_ret_table = monthly_ret_table.unstack().round(3)
 
     sns.heatmap(
@@ -243,7 +242,7 @@ def plot_annual_returns(returns, ax=None, **kwargs):
     ax.tick_params(axis='x', which='major', labelsize=10)
 
     ann_ret_df = pd.DataFrame(
-        timeseries.aggregate_returns(
+        qrisk.aggregate_returns(
             returns,
             'yearly'))
 
@@ -292,7 +291,7 @@ def plot_monthly_returns_dist(returns, ax=None, **kwargs):
     ax.xaxis.set_major_formatter(FuncFormatter(x_axis_formatter))
     ax.tick_params(axis='x', which='major', labelsize=10)
 
-    monthly_ret_table = timeseries.aggregate_returns(returns, 'monthly')
+    monthly_ret_table = qrisk.aggregate_returns(returns, 'monthly')
 
     ax.hist(
         100 * monthly_ret_table,
@@ -405,7 +404,7 @@ def plot_drawdown_periods(returns, top=10, ax=None, **kwargs):
     y_axis_formatter = FuncFormatter(utils.one_dec_places)
     ax.yaxis.set_major_formatter(FuncFormatter(y_axis_formatter))
 
-    df_cum_rets = timeseries.cum_returns(returns, starting_value=1.0)
+    df_cum_rets = qrisk.cum_returns(returns, starting_value=1.0)
     df_drawdowns = timeseries.gen_drawdown_table(returns, top=top)
 
     df_cum_rets.plot(ax=ax, **kwargs)
@@ -456,7 +455,7 @@ def plot_drawdown_underwater(returns, ax=None, **kwargs):
     y_axis_formatter = FuncFormatter(utils.percentage)
     ax.yaxis.set_major_formatter(FuncFormatter(y_axis_formatter))
 
-    df_cum_rets = timeseries.cum_returns(returns, starting_value=1.0)
+    df_cum_rets = qrisk.cum_returns(returns, starting_value=1.0)
     running_max = np.maximum.accumulate(df_cum_rets)
     underwater = -100 * ((running_max - df_cum_rets) / running_max)
     (underwater).plot(ax=ax, kind='area', color='coral', alpha=0.7, **kwargs)
@@ -691,13 +690,13 @@ def plot_rolling_returns(returns,
         bmark_vol = factor_returns.loc[returns.index].std()
         returns = (returns / returns.std()) * bmark_vol
 
-    cum_rets = timeseries.cum_returns(returns, 1.0)
+    cum_rets = qrisk.cum_returns(returns, 1.0)
 
     y_axis_formatter = FuncFormatter(utils.one_dec_places)
     ax.yaxis.set_major_formatter(FuncFormatter(y_axis_formatter))
 
     if factor_returns is not None:
-        cum_factor_returns = timeseries.cum_returns(
+        cum_factor_returns = qrisk.cum_returns(
             factor_returns[cum_rets.index], 1.0)
         cum_factor_returns.plot(lw=2, color='gray',
                                 label=factor_returns.name, alpha=0.60,
@@ -917,7 +916,7 @@ def plot_exposures(returns, positions_alloc, ax=None, **kwargs):
     df_long_short.plot(
         kind='line', style=['-g', '-r', '--k'], alpha=1.0,
         ax=ax, **kwargs)
-    df_cum_rets = timeseries.cum_returns(returns, starting_value=1)
+    df_cum_rets = qrisk.cum_returns(returns, starting_value=1)
     ax.set_xlim((df_cum_rets.index[0], df_cum_rets.index[-1]))
     ax.set_title("Long/Short Exposure")
     ax.set_ylabel('Exposure')
@@ -1003,7 +1002,7 @@ def show_and_plot_top_positions(returns, positions_alloc,
         else:
             ax.legend(loc=legend_loc)
 
-        df_cum_rets = timeseries.cum_returns(returns, starting_value=1)
+        df_cum_rets = qrisk.cum_returns(returns, starting_value=1)
         ax.set_xlim((df_cum_rets.index[0], df_cum_rets.index[-1]))
         ax.set_ylabel('Exposure by stock')
 
@@ -1114,16 +1113,16 @@ def plot_return_quantiles(returns, live_start_date=None, ax=None, **kwargs):
 
     is_returns = returns if live_start_date is None \
         else returns.loc[returns.index < live_start_date]
-    is_weekly = timeseries.aggregate_returns(is_returns, 'weekly')
-    is_monthly = timeseries.aggregate_returns(is_returns, 'monthly')
+    is_weekly = qrisk.aggregate_returns(is_returns, 'weekly')
+    is_monthly = qrisk.aggregate_returns(is_returns, 'monthly')
     sns.boxplot(data=[is_returns, is_weekly, is_monthly],
                 palette=["#4c72B0", "#55A868", "#CCB974"],
                 ax=ax, **kwargs)
 
     if live_start_date is not None:
         oos_returns = returns.loc[returns.index >= live_start_date]
-        oos_weekly = timeseries.aggregate_returns(oos_returns, 'weekly')
-        oos_monthly = timeseries.aggregate_returns(oos_returns, 'monthly')
+        oos_weekly = qrisk.aggregate_returns(oos_returns, 'weekly')
+        oos_monthly = qrisk.aggregate_returns(oos_returns, 'monthly')
 
         sns.swarmplot(data=[oos_returns, oos_weekly, oos_monthly], ax=ax,
                       color="red",
@@ -1149,7 +1148,7 @@ def show_return_range(returns):
          - See full explanation in tears.create_full_tear_sheet.
     """
 
-    df_weekly = timeseries.aggregate_returns(returns, 'weekly')
+    df_weekly = qrisk.aggregate_returns(returns, 'weekly')
 
     two_sigma_daily = returns.mean() - 2 * returns.std()
     two_sigma_weekly = df_weekly.mean() - 2 * df_weekly.std()
@@ -1218,7 +1217,7 @@ def plot_turnover(returns, transactions, positions,
                'Average daily turnover, net'],
               loc=legend_loc)
     ax.set_title('Daily Turnover')
-    df_cum_rets = timeseries.cum_returns(returns, starting_value=1)
+    df_cum_rets = qrisk.cum_returns(returns, starting_value=1)
     ax.set_xlim((df_cum_rets.index[0], df_cum_rets.index[-1]))
     ax.set_ylim((0, 1))
     ax.set_ylabel('Turnover')
@@ -1266,7 +1265,7 @@ def plot_slippage_sweep(returns, transactions, positions,
     for bps in slippage_params:
         adj_returns = txn.adjust_returns_for_slippage(returns, turnover, bps)
         label = str(bps) + " bps"
-        slippage_sweep[label] = timeseries.cum_returns(adj_returns, 1)
+        slippage_sweep[label] = qrisk.cum_returns(adj_returns, 1)
 
     slippage_sweep.plot(alpha=1.0, lw=0.5, ax=ax)
 
@@ -1422,7 +1421,7 @@ def plot_daily_volume(returns, transactions, ax=None, **kwargs):
     ax.axhline(daily_txn.txn_shares.mean(), color='steelblue',
                linestyle='--', lw=3, alpha=1.0)
     ax.set_title('Daily Trading Volume')
-    df_cum_rets = timeseries.cum_returns(returns, starting_value=1)
+    df_cum_rets = qrisk.cum_returns(returns, starting_value=1)
     ax.set_xlim((df_cum_rets.index[0], df_cum_rets.index[-1]))
     ax.set_ylabel('Amount of shares traded')
     ax.set_xlabel('')
@@ -1516,7 +1515,7 @@ def plot_monthly_returns_timeseries(returns, ax=None, **kwargs):
     """
 
     def cumulate_returns(x):
-        return timeseries.cum_returns(x)[-1]
+        return qrisk.cum_returns(x)[-1]
 
     if ax is None:
         ax = plt.gca()
@@ -1720,7 +1719,7 @@ def plot_multistrike_cones(is_returns, oos_returns, num_samples=1000,
     else:
         axes = ax
 
-    returns = timeseries.cum_returns(oos_returns, starting_value=1.)
+    returns = qrisk.cum_returns(oos_returns, starting_value=1.)
     bounds = timeseries.forecast_cone_bootstrap(is_returns,
                                                 len(oos_returns),
                                                 cone_std=cone_std,

--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -39,6 +39,7 @@ from .utils import (APPROX_BDAYS_PER_MONTH,
                     MM_DISPLAY_UNIT)
 
 from functools import wraps
+import qrisk
 
 
 def plotting_context(func):
@@ -1311,8 +1312,7 @@ def plot_slippage_sensitivity(returns, transactions, positions,
     avg_returns_given_slippage = pd.Series()
     for bps in range(1, 100):
         adj_returns = txn.adjust_returns_for_slippage(returns, turnover, bps)
-        avg_returns = timeseries.annual_return(
-            adj_returns)
+        avg_returns = qrisk.annual_return(adj_returns)
         avg_returns_given_slippage.loc[bps] = avg_returns
 
     avg_returns_given_slippage.plot(alpha=1.0, lw=2, ax=ax)
@@ -1340,7 +1340,7 @@ def plot_capacity_sweep(returns, transactions, market_data,
                                                   txn_daily_w_bar,
                                                   start_pv,
                                                   bt_starting_capital)
-        sharpe = timeseries.sharpe_ratio(adj_ret)
+        sharpe = qrisk.sharpe_ratio(adj_ret)
         if sharpe < -1:
             break
         captial_base_sweep.loc[start_pv] = sharpe

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -32,6 +32,7 @@ from . import capacity
 from . import plotting
 from . import _seaborn as sns
 from .plotting import plotting_context
+import qrisk
 
 try:
     from . import bayesian
@@ -252,7 +253,7 @@ def create_returns_tear_sheet(returns, live_start_date=None,
         if returns.index[0] < benchmark_rets.index[0]:
             returns = returns[returns.index > benchmark_rets.index[0]]
 
-    df_cum_rets = timeseries.cum_returns(returns, starting_value=1)
+    df_cum_rets = qrisk.cum_returns(returns, starting_value=1)
     print("Entire data start date: " + str(df_cum_rets
                                            .index[0].strftime('%Y-%m-%d')))
     print("Entire data end date: " + str(df_cum_rets
@@ -693,9 +694,9 @@ def create_interesting_times_tear_sheet(
 
         # i=0 -> 0, i=1 -> 0, i=2 -> 1 ;; i=0 -> 0, i=1 -> 1, i=2 -> 0
         ax = plt.subplot(gs[int(i / 2.0), i % 2])
-        timeseries.cum_returns(rets_period).plot(
+        qrisk.cum_returns(rets_period).plot(
             ax=ax, color='forestgreen', label='algo', alpha=0.7, lw=2)
-        timeseries.cum_returns(bmark_interesting[name]).plot(
+        qrisk.cum_returns(bmark_interesting[name]).plot(
             ax=ax, color='gray', label='SPY', alpha=0.6)
         ax.legend(['algo',
                    'SPY'],

--- a/pyfolio/tests/test_timeseries.py
+++ b/pyfolio/tests/test_timeseries.py
@@ -6,7 +6,6 @@ from numpy.testing import assert_allclose, assert_almost_equal
 
 import numpy as np
 import pandas as pd
-import pandas.util.testing as pdt
 
 from .. import timeseries
 from .. import utils
@@ -181,18 +180,6 @@ class TestDrawdown(TestCase):
             self.assertLessEqual(recovery, peak)
 
     @parameterized.expand([
-        (pd.Series(px_list_1 - 1, index=dt), -0.44000000000000011)
-    ])
-    def test_max_drawdown(self, returns, expected):
-        self.assertEqual(timeseries.max_drawdown(returns), expected)
-
-    @parameterized.expand([
-        (pd.Series(px_list_1 - 1, index=dt), -0.44000000000000011)
-    ])
-    def test_max_drawdown_underwater(self, underwater, expected):
-        self.assertEqual(timeseries.max_drawdown(underwater), expected)
-
-    @parameterized.expand([
         (pd.Series(px_list_1,
                    index=dt),
          1,
@@ -206,20 +193,6 @@ class TestDrawdown(TestCase):
                 returns,
                 top=top),
             expected)
-
-
-class TestCumReturns(TestCase):
-    dt = pd.date_range('2000-1-3', periods=3, freq='D')
-
-    @parameterized.expand([
-        (pd.Series([.1, -.05, .1], index=dt),
-         pd.Series([1.1, 1.1 * .95, 1.1 * .95 * 1.1], index=dt), 1.),
-        (pd.Series([np.nan, -.05, .1], index=dt),
-         pd.Series([1., 1. * .95, 1. * .95 * 1.1], index=dt), 1.),
-    ])
-    def test_expected_result(self, input, expected, starting_value):
-        output = timeseries.cum_returns(input, starting_value=starting_value)
-        pdt.assert_series_equal(output, expected)
 
 
 class TestVariance(TestCase):
@@ -247,27 +220,6 @@ class TestNormalize(TestCase):
     ])
     def test_normalize(self, returns, expected):
         self.assertTrue(timeseries.normalize(returns).equals(expected))
-
-
-class TestAggregateReturns(TestCase):
-    simple_rets = pd.Series(
-        [0.1] * 3 + [0] * 497,
-        pd.date_range(
-            '2000-1-3',
-            periods=500,
-            freq='D'))
-
-    @parameterized.expand([
-        (simple_rets, 'yearly', [0.33099999999999996, 0.0]),
-        (simple_rets[:100], 'monthly', [0.33099999999999996, 0.0, 0.0, 0.0]),
-        (simple_rets[:20], 'weekly', [0.33099999999999996, 0.0, 0.0])
-    ])
-    def test_aggregate_rets(self, returns, convert_to, expected):
-        self.assertEqual(
-            timeseries.aggregate_returns(
-                returns,
-                convert_to).values.tolist(),
-            expected)
 
 
 class TestStats(TestCase):
@@ -306,61 +258,11 @@ class TestStats(TestCase):
     dt_2 = pd.date_range('2000-1-3', periods=8, freq='D')
 
     @parameterized.expand([
-        (simple_rets, utils.DAILY, 0.15500998835658053),
-        (simple_week_rets, utils.WEEKLY, 0.030183329386562319),
-        (simple_month_rets, utils.MONTHLY, 0.006885932704891129)
-    ])
-    def test_annual_ret(self, returns, period, expected):
-        self.assertEqual(
-            timeseries.annual_return(
-                returns,
-                period=period
-            ),
-            expected)
-
-    @parameterized.expand([
-        (simple_rets, utils.DAILY, 0.12271674212427248),
-        (simple_rets, utils.DAILY, 0.12271674212427248),
-        (simple_week_rets, utils.WEEKLY, 0.055744909991675112),
-        (simple_week_rets, utils.WEEKLY, 0.055744909991675112),
-        (simple_month_rets, utils.MONTHLY, 0.026778988562993072),
-        (simple_month_rets, utils.MONTHLY, 0.026778988562993072)
-    ])
-    def test_annual_volatility(self, returns, period, expected):
-        self.assertAlmostEqual(
-            timeseries.annual_volatility(
-                returns,
-                period=period
-            ),
-            expected,
-            DECIMAL_PLACES
-        )
-
-    @parameterized.expand([
-        (simple_rets, 1.2321057207245873),
-        (np.zeros(10), np.nan),
-        ([0.1, 0.2, 0.3], np.nan)
-    ])
-    def test_sharpe(self, returns, expected):
-        assert_almost_equal(
-            timeseries.sharpe_ratio(
-                returns),
-            expected, DECIMAL_PLACES)
-
-    @parameterized.expand([
         (simple_rets[:5], 2, '[nan, inf, inf, 11.224972160321828, inf]')
     ])
     def test_sharpe_2(self, returns, rolling_sharpe_window, expected):
         self.assertEqual(str(timeseries.rolling_sharpe(
             returns, rolling_sharpe_window).values.tolist()), expected)
-
-    @parameterized.expand([
-        (simple_rets, 0.010766923838470142)
-    ])
-    def test_stability_of_timeseries(self, returns, expected):
-        self.assertAlmostEqual(
-            timeseries.stability_of_timeseries(returns),
-            expected, DECIMAL_PLACES)
 
     @parameterized.expand([
         (simple_rets[:5], simple_benchmark[:5], 2, 8.024708101613483e-32)
@@ -372,49 +274,6 @@ class TestStats(TestCase):
                 benchmark_rets,
                 rolling_window=rolling_window).values.tolist()[2],
             expected)
-
-    @parameterized.expand([
-        (pd.Series(px_list_2,
-                   index=dt_2).pct_change().dropna(), -2.3992211554712197)
-    ])
-    def test_calmar(self, returns, expected):
-        self.assertEqual(
-            timeseries.calmar_ratio(
-                returns),
-            expected)
-
-    @parameterized.expand([
-        (pd.Series(px_list,
-                   index=dt), 0.0, 2.0)
-    ])
-    def test_omega(self, returns, annual_return_threshhold, expected):
-        self.assertEqual(
-            timeseries.omega_ratio(
-                returns,
-                annual_return_threshhold=annual_return_threshhold),
-            expected)
-
-    @parameterized.expand([
-        (-simple_rets[:5], -12.29634091915152),
-        (-simple_rets, -1.2296340919151518),
-        (simple_rets, np.inf)
-    ])
-    def test_sortino(self, returns, expected):
-        self.assertAlmostEqual(
-            timeseries.sortino_ratio(returns),
-            expected, DECIMAL_PLACES)
-
-    def test_tail_ratio(self):
-        returns = np.random.randn(10000)
-        self.assertAlmostEqual(
-            timeseries.tail_ratio(returns),
-            1., 1)
-
-    def test_common_sense_ratio(self):
-        returns = pd.Series(np.random.randn(1000) + .1)
-        self.assertAlmostEqual(
-            timeseries.common_sense_ratio(returns),
-            0.024031933021535612, DECIMAL_PLACES)
 
 
 class TestMultifactor(TestCase):

--- a/pyfolio/tests/test_timeseries.py
+++ b/pyfolio/tests/test_timeseries.py
@@ -258,12 +258,12 @@ class TestAggregateReturns(TestCase):
             freq='D'))
 
     @parameterized.expand([
-        (simple_rets, 'yearly', [0.3310000000000004, 0.0]),
-        (simple_rets[:100], 'monthly', [0.3310000000000004, 0.0, 0.0, 0.0]),
-        (simple_rets[:20], 'weekly', [0.3310000000000004, 0.0, 0.0])
+        (simple_rets, 'yearly', [0.33099999999999996, 0.0]),
+        (simple_rets[:100], 'monthly', [0.33099999999999996, 0.0, 0.0, 0.0]),
+        (simple_rets[:20], 'weekly', [0.33099999999999996, 0.0, 0.0])
     ])
     def test_aggregate_rets(self, returns, convert_to, expected):
-        assert_almost_equal(
+        self.assertEqual(
             timeseries.aggregate_returns(
                 returns,
                 convert_to).values.tolist(),
@@ -306,18 +306,17 @@ class TestStats(TestCase):
     dt_2 = pd.date_range('2000-1-3', periods=8, freq='D')
 
     @parameterized.expand([
-        (simple_rets, utils.DAILY, 0.15500998835658075),
+        (simple_rets, utils.DAILY, 0.15500998835658053),
         (simple_week_rets, utils.WEEKLY, 0.030183329386562319),
         (simple_month_rets, utils.MONTHLY, 0.006885932704891129)
     ])
     def test_annual_ret(self, returns, period, expected):
-        assert_almost_equal(
+        self.assertEqual(
             timeseries.annual_return(
                 returns,
                 period=period
             ),
-            expected,
-            DECIMAL_PLACES)
+            expected)
 
     @parameterized.expand([
         (simple_rets, utils.DAILY, 0.12271674212427248),

--- a/pyfolio/tests/test_timeseries.py
+++ b/pyfolio/tests/test_timeseries.py
@@ -263,7 +263,7 @@ class TestAggregateReturns(TestCase):
         (simple_rets[:20], 'weekly', [0.3310000000000004, 0.0, 0.0])
     ])
     def test_aggregate_rets(self, returns, convert_to, expected):
-        self.assertEqual(
+        assert_almost_equal(
             timeseries.aggregate_returns(
                 returns,
                 convert_to).values.tolist(),

--- a/pyfolio/tests/test_timeseries.py
+++ b/pyfolio/tests/test_timeseries.py
@@ -311,12 +311,13 @@ class TestStats(TestCase):
         (simple_month_rets, utils.MONTHLY, 0.006885932704891129)
     ])
     def test_annual_ret(self, returns, period, expected):
-        self.assertEqual(
+        assert_almost_equal(
             timeseries.annual_return(
                 returns,
                 period=period
             ),
-            expected)
+            expected,
+            DECIMAL_PLACES)
 
     @parameterized.expand([
         (simple_rets, utils.DAILY, 0.12271674212427248),
@@ -337,7 +338,7 @@ class TestStats(TestCase):
         )
 
     @parameterized.expand([
-        (simple_rets, 1.2333396776895436),
+        (simple_rets, 1.2321057207245873),
         (np.zeros(10), np.nan),
         ([0.1, 0.2, 0.3], np.nan)
     ])
@@ -355,7 +356,7 @@ class TestStats(TestCase):
             returns, rolling_sharpe_window).values.tolist()), expected)
 
     @parameterized.expand([
-        (simple_rets, 0.10376378866671222)
+        (simple_rets, 0.010766923838470142)
     ])
     def test_stability_of_timeseries(self, returns, expected):
         self.assertAlmostEqual(

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -26,8 +26,13 @@ from . import utils
 from .utils import APPROX_BDAYS_PER_MONTH, APPROX_BDAYS_PER_YEAR
 from .utils import DAILY
 from .interesting_periods import PERIODS
+from .deprecate import deprecated
 
 import qrisk
+
+DEPRECATION_WARNING = ("Risk functions in pyfolio.timeseries are deprecated "
+                       "and will be removed in a future release. Please "
+                       "install the qrisk package instead.")
 
 
 def var_cov_var_normal(P, c, mu=0, sigma=1):
@@ -54,6 +59,7 @@ def var_cov_var_normal(P, c, mu=0, sigma=1):
     return P - P * (alpha + 1)
 
 
+@deprecated(msg=DEPRECATION_WARNING)
 def max_drawdown(returns):
     """
     Determines the maximum drawdown of a strategy.
@@ -77,6 +83,7 @@ def max_drawdown(returns):
     return qrisk.max_drawdown(returns)
 
 
+@deprecated(msg=DEPRECATION_WARNING)
 def annual_return(returns, period=DAILY):
     """Determines the mean annual growth rate of returns.
 
@@ -100,6 +107,7 @@ def annual_return(returns, period=DAILY):
     return qrisk.annual_return(returns, period=period)
 
 
+@deprecated(msg=DEPRECATION_WARNING)
 def annual_volatility(returns, period=DAILY):
     """
     Determines the annual volatility of a strategy.
@@ -123,6 +131,7 @@ def annual_volatility(returns, period=DAILY):
     return qrisk.annual_volatility(returns, period=period)
 
 
+@deprecated(msg=DEPRECATION_WARNING)
 def calmar_ratio(returns, period=DAILY):
     """
     Determines the Calmar ratio, or drawdown ratio, of a strategy.
@@ -151,6 +160,7 @@ def calmar_ratio(returns, period=DAILY):
     return qrisk.calmar_ratio(returns, period=period)
 
 
+@deprecated(msg=DEPRECATION_WARNING)
 def omega_ratio(returns, annual_return_threshhold=0.0):
     """Determines the Omega ratio of a strategy.
 
@@ -187,6 +197,7 @@ def omega_ratio(returns, annual_return_threshhold=0.0):
     return qrisk.omega_ratio(returns, required_return=annual_return_threshhold)
 
 
+@deprecated(msg=DEPRECATION_WARNING)
 def sortino_ratio(returns, required_return=0, period=DAILY):
     """
     Determines the Sortino ratio of a strategy.
@@ -216,6 +227,7 @@ def sortino_ratio(returns, required_return=0, period=DAILY):
     return qrisk.sortino_ratio(returns, required_return=required_return)
 
 
+@deprecated(msg=DEPRECATION_WARNING)
 def downside_risk(returns, required_return=0, period=DAILY):
     """
     Determines the downside deviation below a threshold
@@ -247,6 +259,7 @@ def downside_risk(returns, required_return=0, period=DAILY):
                                period=period)
 
 
+@deprecated(msg=DEPRECATION_WARNING)
 def sharpe_ratio(returns, risk_free=0, period=DAILY):
     """
     Determines the Sharpe ratio of a strategy.
@@ -279,6 +292,7 @@ def sharpe_ratio(returns, risk_free=0, period=DAILY):
     return qrisk.sharpe_ratio(returns, risk_free=risk_free, period=period)
 
 
+@deprecated(msg=DEPRECATION_WARNING)
 def information_ratio(returns, factor_returns):
     """
     Determines the Information ratio of a strategy.
@@ -305,6 +319,7 @@ def information_ratio(returns, factor_returns):
     return qrisk.information_ratio(returns, factor_returns)
 
 
+@deprecated(msg=DEPRECATION_WARNING)
 def alpha_beta(returns, factor_returns):
     """Calculates both alpha and beta.
 
@@ -330,8 +345,9 @@ def alpha_beta(returns, factor_returns):
     return qrisk.alpha_beta(returns, factor_returns=factor_returns)
 
 
+@deprecated(msg=DEPRECATION_WARNING)
 def alpha(returns, factor_returns):
-    """Calculates alpha.
+    """Calculates annualized alpha.
 
     Parameters
     ----------
@@ -352,6 +368,7 @@ def alpha(returns, factor_returns):
     return qrisk.alpha(returns, factor_returns=factor_returns)
 
 
+@deprecated(msg=DEPRECATION_WARNING)
 def beta(returns, factor_returns):
     """Calculates beta.
 
@@ -374,6 +391,7 @@ def beta(returns, factor_returns):
     return qrisk.beta(returns, factor_returns)
 
 
+@deprecated(msg=DEPRECATION_WARNING)
 def stability_of_timeseries(returns):
     """Determines R-squared of a linear fit to the cumulative
     log returns. Computes an ordinary least squares linear fit,
@@ -395,6 +413,7 @@ def stability_of_timeseries(returns):
     return qrisk.stability_of_timeseries(returns)
 
 
+@deprecated(msg=DEPRECATION_WARNING)
 def tail_ratio(returns):
     """Determines the ratio between the right (95%) and left tail (5%).
 
@@ -437,7 +456,7 @@ def common_sense_ratio(returns):
         common sense ratio
 
     """
-    return tail_ratio(returns) * (1 + annual_return(returns))
+    return qrisk.tail_ratio(returns) * (1 + qrisk.annual_return(returns))
 
 
 SIMPLE_STAT_FUNCS = [
@@ -483,6 +502,7 @@ def normalize(returns, starting_value=1):
     return starting_value * (returns / returns.iloc[0])
 
 
+@deprecated(msg=DEPRECATION_WARNING)
 def cum_returns(returns, starting_value=0):
     """
     Compute cumulative returns from simple returns.
@@ -509,6 +529,7 @@ def cum_returns(returns, starting_value=0):
     return qrisk.cum_returns(returns, starting_value=starting_value)
 
 
+@deprecated(msg=DEPRECATION_WARNING)
 def aggregate_returns(returns, convert_to):
     """
     Aggregates returns by week, month, or year.
@@ -593,7 +614,7 @@ def rolling_beta(returns, factor_returns,
         out = pd.Series(index=returns.index)
         for beg, end in zip(returns.index[0:-rolling_window],
                             returns.index[rolling_window:]):
-            out.loc[end] = alpha_beta(
+            out.loc[end] = qrisk.alpha_beta(
                 returns.loc[beg:end],
                 factor_returns.loc[beg:end])[1]
 

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -78,22 +78,21 @@ def max_drawdown(returns):
 
 
 def annual_return(returns, period=DAILY):
-    """Determines the annual returns of a strategy.
+    """Determines the mean annual growth rate of returns.
 
     Parameters
     ----------
     returns : pd.Series
         Periodic returns of the strategy, noncumulative.
-         - See full explanation in tears.create_full_tear_sheet.
+        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
     period : str, optional
-        - defines the periodicity of the 'returns' data for purposes of
-        annualizing. Can be 'monthly', 'weekly', or 'daily'
-        - defaults to 'daily'.
+        Defines the periodicity of the 'returns' data for purposes of
+        annualizing. Can be 'monthly', 'weekly', or 'daily'.
 
     Returns
     -------
     float
-        Annual Return as CAGR (Compounded Annual Growth Rate)
+        Annual Return as CAGR (Compounded Annual Growth Rate).
 
     """
 
@@ -108,11 +107,10 @@ def annual_volatility(returns, period=DAILY):
     ----------
     returns : pd.Series
         Periodic returns of the strategy, noncumulative.
-         - See full explanation in tears.create_full_tear_sheet.
+        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
     period : str, optional
-        - defines the periodicity of the 'returns' data for purposes of
+        Defines the periodicity of the 'returns' data for purposes of
         annualizing volatility. Can be 'monthly' or 'weekly' or 'daily'.
-        - defaults to 'daily'
 
     Returns
     -------
@@ -131,17 +129,16 @@ def calmar_ratio(returns, period=DAILY):
     ----------
     returns : pd.Series
         Daily returns of the strategy, noncumulative.
-         - See full explanation in tears.create_full_tear_sheet.
+        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
     period : str, optional
-        - defines the periodicity of the 'returns' data for purposes of
-        annualizing. Can be 'monthly', 'weekly', or 'daily'
-        - defaults to 'daily'.
-
+        Defines the periodicity of the 'returns' data for purposes of
+        annualizing. Can be 'monthly', 'weekly', or 'daily'.
 
     Returns
     -------
     float
-        Calmar ratio (drawdown ratio).
+        Calmar ratio (drawdown ratio) as float. Returns np.nan if there is no
+        calmar ratio.
 
     Note
     -----
@@ -158,11 +155,13 @@ def omega_ratio(returns, annual_return_threshhold=0.0):
     ----------
     returns : pd.Series
         Daily returns of the strategy, noncumulative.
-         - See full explanation in tears.create_full_tear_sheet.
+        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
     annual_return_threshold : float, optional
-        Threshold over which to consider positive vs negative
-        returns. For the ratio, it will be converted to a daily return
-        and compared to returns.
+        Minimum acceptance return of the investor. Threshold over which to
+        consider positive vs negative returns. It will be converted to a
+        value appropriate for the period of the returns. E.g. An annual minimum
+        acceptable return of 100 will translate to a minimum acceptable
+        return of 0.018.
 
     Returns
     -------
@@ -186,13 +185,12 @@ def sortino_ratio(returns, required_return=0, period=DAILY):
     ----------
     returns : pd.Series or pd.DataFrame
         Daily returns of the strategy, noncumulative.
-         - See full explanation in tears.create_full_tear_sheet.
+        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
     required_return: float / series
         minimum acceptable return
     period : str, optional
-        - defines the periodicity of the 'returns' data for purposes of
-        annualizing. Can be 'monthly', 'weekly', or 'daily'
-        - defaults to 'daily'.
+        Defines the periodicity of the 'returns' data for purposes of
+        annualizing. Can be 'monthly', 'weekly', or 'daily'.
 
     Returns
     -------
@@ -215,14 +213,12 @@ def downside_risk(returns, required_return=0, period=DAILY):
     ----------
     returns : pd.Series or pd.DataFrame
         Daily returns of the strategy, noncumulative.
-         - See full explanation in tears.create_full_tear_sheet.
-
+        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
     required_return: float / series
         minimum acceptable return
     period : str, optional
-        - defines the periodicity of the 'returns' data for purposes of
-        annualizing. Can be 'monthly', 'weekly', or 'daily'
-        - defaults to 'daily'.
+        Defines the periodicity of the 'returns' data for purposes of
+        annualizing. Can be 'monthly', 'weekly', or 'daily'.
 
     Returns
     -------
@@ -234,7 +230,8 @@ def downside_risk(returns, required_return=0, period=DAILY):
 
     """
 
-    return qrisk.downside_risk(returns, required_return=required_return,
+    return qrisk.downside_risk(returns,
+                               required_return=required_return,
                                period=period)
 
 
@@ -246,20 +243,24 @@ def sharpe_ratio(returns, risk_free=0, period=DAILY):
     ----------
     returns : pd.Series
         Daily returns of the strategy, noncumulative.
-         - See full explanation in tears.create_full_tear_sheet.
+        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
+    risk_free : int, float
+        Constant risk-free return throughout the period.
     period : str, optional
-        - defines the periodicity of the 'returns' data for purposes of
-        annualizing. Can be 'monthly', 'weekly', or 'daily'
-        - defaults to 'daily'.
+        Defines the periodicity of the 'returns' data for purposes of
+        annualizing. Can be 'monthly', 'weekly', or 'daily'.
 
     Returns
     -------
     float
         Sharpe ratio.
+    np.nan
+        If insufficient length of returns or if if adjusted returns are 0.
 
     Note
     -----
     See https://en.wikipedia.org/wiki/Sharpe_ratio for more details.
+
     """
 
     return qrisk.sharpe_ratio(returns, risk_free=risk_free, period=period)
@@ -273,8 +274,9 @@ def information_ratio(returns, factor_returns):
     ----------
     returns : pd.Series or pd.DataFrame
         Daily returns of the strategy, noncumulative.
-         - See full explanation in tears.create_full_tear_sheet.
+        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
     factor_returns: float / series
+        Benchmark return to compare returns against.
 
     Returns
     -------
@@ -297,7 +299,7 @@ def alpha_beta(returns, factor_returns):
     ----------
     returns : pd.Series
         Daily returns of the strategy, noncumulative.
-         - See full explanation in tears.create_full_tear_sheet.
+        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
     factor_returns : pd.Series
          Daily noncumulative returns of the factor to which beta is
          computed. Usually a benchmark such as the market.
@@ -316,13 +318,13 @@ def alpha_beta(returns, factor_returns):
 
 
 def alpha(returns, factor_returns):
-    """Calculates annualized alpha.
+    """Calculates alpha.
 
     Parameters
     ----------
     returns : pd.Series
         Daily returns of the strategy, noncumulative.
-         - See full explanation in tears.create_full_tear_sheet.
+        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
     factor_returns : pd.Series
          Daily noncumulative returns of the factor to which beta is
          computed. Usually a benchmark such as the market.
@@ -344,7 +346,7 @@ def beta(returns, factor_returns):
     ----------
     returns : pd.Series
         Daily returns of the strategy, noncumulative.
-         - See full explanation in tears.create_full_tear_sheet.
+        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
     factor_returns : pd.Series
          Daily noncumulative returns of the factor to which beta is
          computed. Usually a benchmark such as the market.
@@ -354,7 +356,7 @@ def beta(returns, factor_returns):
     -------
     float
         Beta.
-"""
+    """
 
     return qrisk.beta(returns, factor_returns)
 
@@ -368,7 +370,7 @@ def stability_of_timeseries(returns):
     ----------
     returns : pd.Series
         Daily returns of the strategy, noncumulative.
-         - See full explanation in tears.create_full_tear_sheet.
+        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
 
     Returns
     -------
@@ -390,7 +392,7 @@ def tail_ratio(returns):
     ----------
     returns : pd.Series
         Daily returns of the strategy, noncumulative.
-         - See full explanation in tears.create_full_tear_sheet.
+         - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
 
     Returns
     -------
@@ -491,7 +493,8 @@ def cum_returns(returns, starting_value=None):
     where it is possible to sum instead of multiplying.
     """
 
-    return qrisk.cum_returns(returns, starting_value=starting_value)
+    starting = 0 if starting_value is None else starting_value
+    return qrisk.cum_returns(returns, starting_value=starting)
 
 
 def aggregate_returns(returns, convert_to):
@@ -500,9 +503,9 @@ def aggregate_returns(returns, convert_to):
 
     Parameters
     ----------
-    df_daily_rets : pd.Series
+    returns : pd.Series
        Daily returns of the strategy, noncumulative.
-        - See full explanation in tears.create_full_tear_sheet (returns).
+        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
     convert_to : str
         Can be 'weekly', 'monthly', or 'yearly'.
 
@@ -813,22 +816,18 @@ def get_max_drawdown_underwater(underwater):
 
 def get_max_drawdown(returns):
     """
-    Finds maximum drawdown.
+    Determines the maximum drawdown of a strategy.
 
     Parameters
     ----------
     returns : pd.Series
         Daily returns of the strategy, noncumulative.
-         - See full explanation in tears.create_full_tear_sheet.
+        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
 
     Returns
     -------
-    peak : datetime
-        The maximum drawdown's peak.
-    valley : datetime
-        The maximum drawdown's valley.
-    recovery : datetime
-        The maximum drawdown's recovery.
+    float
+        Maximum drawdown.
 
     Note
     -----

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -84,10 +84,11 @@ def annual_return(returns, period=DAILY):
     ----------
     returns : pd.Series
         Periodic returns of the strategy, noncumulative.
-        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
+        - See full explanation in :func:`~pyfolio.timeseries.cum_returns`.
     period : str, optional
         Defines the periodicity of the 'returns' data for purposes of
         annualizing. Can be 'monthly', 'weekly', or 'daily'.
+        - Defaults to 'daily'.
 
     Returns
     -------
@@ -107,10 +108,11 @@ def annual_volatility(returns, period=DAILY):
     ----------
     returns : pd.Series
         Periodic returns of the strategy, noncumulative.
-        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
+        - See full explanation in :func:`~pyfolio.timeseries.cum_returns`.
     period : str, optional
         Defines the periodicity of the 'returns' data for purposes of
         annualizing volatility. Can be 'monthly' or 'weekly' or 'daily'.
+        - Defaults to 'daily'.
 
     Returns
     -------
@@ -129,10 +131,11 @@ def calmar_ratio(returns, period=DAILY):
     ----------
     returns : pd.Series
         Daily returns of the strategy, noncumulative.
-        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
+        - See full explanation in :func:`~pyfolio.timeseries.cum_returns`.
     period : str, optional
         Defines the periodicity of the 'returns' data for purposes of
         annualizing. Can be 'monthly', 'weekly', or 'daily'.
+        - Defaults to 'daily'.
 
     Returns
     -------
@@ -155,13 +158,20 @@ def omega_ratio(returns, annual_return_threshhold=0.0):
     ----------
     returns : pd.Series
         Daily returns of the strategy, noncumulative.
-        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
+        - See full explanation in :func:`~pyfolio.timeseries.cum_returns`.
     annual_return_threshold : float, optional
-        Minimum acceptance return of the investor. Threshold over which to
-        consider positive vs negative returns. It will be converted to a
-        value appropriate for the period of the returns. E.g. An annual minimum
-        acceptable return of 100 will translate to a minimum acceptable
-        return of 0.018.
+        Minimum acceptable return of the investor. Annual threshold over which
+        returns are considered positive or negative. It is converted to a
+        value appropriate for the period of the returns for this ratio.
+        E.g. An annual minimum acceptable return of 100 translates to a daily
+        minimum acceptable return of 0.01848.
+            (1 + 100) ** (1. / 252) - 1 = 0.01848
+        Daily returns must exceed this value to be considered positive. The
+        daily return yields the desired annual return when compounded over
+        the average number of business days in a year.
+            (1 + 0.01848) ** 252 - 1 = 99.93
+        - Defaults to 0.0
+
 
     Returns
     -------
@@ -185,12 +195,13 @@ def sortino_ratio(returns, required_return=0, period=DAILY):
     ----------
     returns : pd.Series or pd.DataFrame
         Daily returns of the strategy, noncumulative.
-        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
+        - See full explanation in :func:`~pyfolio.timeseries.cum_returns`.
     required_return: float / series
         minimum acceptable return
     period : str, optional
         Defines the periodicity of the 'returns' data for purposes of
         annualizing. Can be 'monthly', 'weekly', or 'daily'.
+        - Defaults to 'daily'.
 
     Returns
     -------
@@ -213,12 +224,13 @@ def downside_risk(returns, required_return=0, period=DAILY):
     ----------
     returns : pd.Series or pd.DataFrame
         Daily returns of the strategy, noncumulative.
-        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
+        - See full explanation in :func:`~pyfolio.timeseries.cum_returns`.
     required_return: float / series
         minimum acceptable return
     period : str, optional
         Defines the periodicity of the 'returns' data for purposes of
         annualizing. Can be 'monthly', 'weekly', or 'daily'.
+        - Defaults to 'daily'.
 
     Returns
     -------
@@ -243,12 +255,13 @@ def sharpe_ratio(returns, risk_free=0, period=DAILY):
     ----------
     returns : pd.Series
         Daily returns of the strategy, noncumulative.
-        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
+        - See full explanation in :func:`~pyfolio.timeseries.cum_returns`.
     risk_free : int, float
         Constant risk-free return throughout the period.
     period : str, optional
         Defines the periodicity of the 'returns' data for purposes of
         annualizing. Can be 'monthly', 'weekly', or 'daily'.
+        - Defaults to 'daily'.
 
     Returns
     -------
@@ -274,7 +287,7 @@ def information_ratio(returns, factor_returns):
     ----------
     returns : pd.Series or pd.DataFrame
         Daily returns of the strategy, noncumulative.
-        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
+        - See full explanation in :func:`~pyfolio.timeseries.cum_returns`.
     factor_returns: float / series
         Benchmark return to compare returns against.
 
@@ -299,7 +312,7 @@ def alpha_beta(returns, factor_returns):
     ----------
     returns : pd.Series
         Daily returns of the strategy, noncumulative.
-        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
+        - See full explanation in :func:`~pyfolio.timeseries.cum_returns`.
     factor_returns : pd.Series
          Daily noncumulative returns of the factor to which beta is
          computed. Usually a benchmark such as the market.
@@ -324,7 +337,7 @@ def alpha(returns, factor_returns):
     ----------
     returns : pd.Series
         Daily returns of the strategy, noncumulative.
-        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
+        - See full explanation in :func:`~pyfolio.timeseries.cum_returns`.
     factor_returns : pd.Series
          Daily noncumulative returns of the factor to which beta is
          computed. Usually a benchmark such as the market.
@@ -346,7 +359,7 @@ def beta(returns, factor_returns):
     ----------
     returns : pd.Series
         Daily returns of the strategy, noncumulative.
-        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
+        - See full explanation in :func:`~pyfolio.timeseries.cum_returns`.
     factor_returns : pd.Series
          Daily noncumulative returns of the factor to which beta is
          computed. Usually a benchmark such as the market.
@@ -370,7 +383,7 @@ def stability_of_timeseries(returns):
     ----------
     returns : pd.Series
         Daily returns of the strategy, noncumulative.
-        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
+        - See full explanation in :func:`~pyfolio.timeseries.cum_returns`.
 
     Returns
     -------
@@ -392,7 +405,7 @@ def tail_ratio(returns):
     ----------
     returns : pd.Series
         Daily returns of the strategy, noncumulative.
-         - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
+         - See full explanation in :func:`~pyfolio.timeseries.cum_returns`.
 
     Returns
     -------
@@ -470,7 +483,7 @@ def normalize(returns, starting_value=1):
     return starting_value * (returns / returns.iloc[0])
 
 
-def cum_returns(returns, starting_value=None):
+def cum_returns(returns, starting_value=0):
     """
     Compute cumulative returns from simple returns.
 
@@ -493,8 +506,7 @@ def cum_returns(returns, starting_value=None):
     where it is possible to sum instead of multiplying.
     """
 
-    starting = 0 if starting_value is None else starting_value
-    return qrisk.cum_returns(returns, starting_value=starting)
+    return qrisk.cum_returns(returns, starting_value=starting_value)
 
 
 def aggregate_returns(returns, convert_to):
@@ -505,7 +517,7 @@ def aggregate_returns(returns, convert_to):
     ----------
     returns : pd.Series
        Daily returns of the strategy, noncumulative.
-        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
+        - See full explanation in :func:`~pyfolio.timeseries.cum_returns`.
     convert_to : str
         Can be 'weekly', 'monthly', or 'yearly'.
 
@@ -822,7 +834,7 @@ def get_max_drawdown(returns):
     ----------
     returns : pd.Series
         Daily returns of the strategy, noncumulative.
-        - See full explanation in :func:`~pyfolio.timseries.cum_returns`.
+        - See full explanation in :func:`~pyfolio.timeseries.cum_returns`.
 
     Returns
     -------

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ install_reqs = [
     'seaborn>=0.6.0',
     'pandas-datareader>=0.2',
     'scikit-learn>=0.17',
-    'qrisk>=0.1.1'
+    'qrisk>=0.1.3'
 ]
 
 extras_reqs = {

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ install_reqs = [
     'seaborn>=0.6.0',
     'pandas-datareader>=0.2',
     'scikit-learn>=0.17',
+    'qrisk>=0.1.1'
 ]
 
 extras_reqs = {


### PR DESCRIPTION
Use qrisk for risk calculations. To preserve backwards compatibility, risk calculation functions are wrappers for corresponding qrisk functions. Risk calculation throughout the project updated to use qrisk instead of internal definition.