### PR TITLE
ENH: Use empyrical instead of qrisk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
 install:
   - conda create -q -n testenv --yes python=$TRAVIS_PYTHON_VERSION ipython pyzmq numpy scipy nose matplotlib pandas Cython patsy statsmodels flake8 scikit-learn seaborn runipy pytables networkx pandas-datareader matplotlib-tests joblib
   - source activate testenv
-  - pip install nose_parameterized qrisk>=0.1.4
+  - pip install nose_parameterized empyrical>=0.1.9
   #- pip install --no-deps git+https://github.com/quantopian/zipline
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then conda install --yes mock enum34; fi
   - pip install --no-deps git+https://github.com/Theano/Theano.git@rel-0.8.1

--- a/pyfolio/bayesian.py
+++ b/pyfolio/bayesian.py
@@ -30,7 +30,7 @@ except ImportError:
     from pymc3 import T as StudentT
 
 from . import _seaborn as sns
-from qrisk import cum_returns
+from empyrical import cum_returns
 
 
 def model_returns_t_alpha_beta(data, bmark, samples=2000):

--- a/pyfolio/capacity.py
+++ b/pyfolio/capacity.py
@@ -2,7 +2,7 @@ from __future__ import division
 import pandas as pd
 import numpy as np
 from . import pos
-import qrisk
+import empyrical
 
 
 def daily_txns_with_bar_data(transactions, market_data):
@@ -233,7 +233,7 @@ def apply_slippage_penalty(returns, txn_daily, simulate_starting_capital,
     # by capital base, it makes the most sense to scale the denominator
     # similarly. In other words, since we aren't applying compounding to
     # simulate_traded_shares, we shouldn't apply compounding to pv.
-    portfolio_value = qrisk.cum_returns(
+    portfolio_value = empyrical.cum_returns(
         returns, starting_value=backtest_starting_capital) * mult
 
     adj_returns = returns - (daily_penalty / portfolio_value)

--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -39,7 +39,7 @@ from .utils import (APPROX_BDAYS_PER_MONTH,
                     MM_DISPLAY_UNIT)
 
 from functools import wraps
-import qrisk
+import empyrical
 
 
 def plotting_context(func):
@@ -194,7 +194,7 @@ def plot_monthly_returns_heatmap(returns, ax=None, **kwargs):
     if ax is None:
         ax = plt.gca()
 
-    monthly_ret_table = qrisk.aggregate_returns(returns, 'monthly')
+    monthly_ret_table = empyrical.aggregate_returns(returns, 'monthly')
     monthly_ret_table = monthly_ret_table.unstack().round(3)
 
     sns.heatmap(
@@ -242,7 +242,7 @@ def plot_annual_returns(returns, ax=None, **kwargs):
     ax.tick_params(axis='x', which='major', labelsize=10)
 
     ann_ret_df = pd.DataFrame(
-        qrisk.aggregate_returns(
+        empyrical.aggregate_returns(
             returns,
             'yearly'))
 
@@ -291,7 +291,7 @@ def plot_monthly_returns_dist(returns, ax=None, **kwargs):
     ax.xaxis.set_major_formatter(FuncFormatter(x_axis_formatter))
     ax.tick_params(axis='x', which='major', labelsize=10)
 
-    monthly_ret_table = qrisk.aggregate_returns(returns, 'monthly')
+    monthly_ret_table = empyrical.aggregate_returns(returns, 'monthly')
 
     ax.hist(
         100 * monthly_ret_table,
@@ -404,7 +404,7 @@ def plot_drawdown_periods(returns, top=10, ax=None, **kwargs):
     y_axis_formatter = FuncFormatter(utils.one_dec_places)
     ax.yaxis.set_major_formatter(FuncFormatter(y_axis_formatter))
 
-    df_cum_rets = qrisk.cum_returns(returns, starting_value=1.0)
+    df_cum_rets = empyrical.cum_returns(returns, starting_value=1.0)
     df_drawdowns = timeseries.gen_drawdown_table(returns, top=top)
 
     df_cum_rets.plot(ax=ax, **kwargs)
@@ -455,7 +455,7 @@ def plot_drawdown_underwater(returns, ax=None, **kwargs):
     y_axis_formatter = FuncFormatter(utils.percentage)
     ax.yaxis.set_major_formatter(FuncFormatter(y_axis_formatter))
 
-    df_cum_rets = qrisk.cum_returns(returns, starting_value=1.0)
+    df_cum_rets = empyrical.cum_returns(returns, starting_value=1.0)
     running_max = np.maximum.accumulate(df_cum_rets)
     underwater = -100 * ((running_max - df_cum_rets) / running_max)
     (underwater).plot(ax=ax, kind='area', color='coral', alpha=0.7, **kwargs)
@@ -690,13 +690,13 @@ def plot_rolling_returns(returns,
         bmark_vol = factor_returns.loc[returns.index].std()
         returns = (returns / returns.std()) * bmark_vol
 
-    cum_rets = qrisk.cum_returns(returns, 1.0)
+    cum_rets = empyrical.cum_returns(returns, 1.0)
 
     y_axis_formatter = FuncFormatter(utils.one_dec_places)
     ax.yaxis.set_major_formatter(FuncFormatter(y_axis_formatter))
 
     if factor_returns is not None:
-        cum_factor_returns = qrisk.cum_returns(
+        cum_factor_returns = empyrical.cum_returns(
             factor_returns[cum_rets.index], 1.0)
         cum_factor_returns.plot(lw=2, color='gray',
                                 label=factor_returns.name, alpha=0.60,
@@ -916,7 +916,7 @@ def plot_exposures(returns, positions_alloc, ax=None, **kwargs):
     df_long_short.plot(
         kind='line', style=['-g', '-r', '--k'], alpha=1.0,
         ax=ax, **kwargs)
-    df_cum_rets = qrisk.cum_returns(returns, starting_value=1)
+    df_cum_rets = empyrical.cum_returns(returns, starting_value=1)
     ax.set_xlim((df_cum_rets.index[0], df_cum_rets.index[-1]))
     ax.set_title("Long/Short Exposure")
     ax.set_ylabel('Exposure')
@@ -1002,7 +1002,7 @@ def show_and_plot_top_positions(returns, positions_alloc,
         else:
             ax.legend(loc=legend_loc)
 
-        df_cum_rets = qrisk.cum_returns(returns, starting_value=1)
+        df_cum_rets = empyrical.cum_returns(returns, starting_value=1)
         ax.set_xlim((df_cum_rets.index[0], df_cum_rets.index[-1]))
         ax.set_ylabel('Exposure by stock')
 
@@ -1113,16 +1113,16 @@ def plot_return_quantiles(returns, live_start_date=None, ax=None, **kwargs):
 
     is_returns = returns if live_start_date is None \
         else returns.loc[returns.index < live_start_date]
-    is_weekly = qrisk.aggregate_returns(is_returns, 'weekly')
-    is_monthly = qrisk.aggregate_returns(is_returns, 'monthly')
+    is_weekly = empyrical.aggregate_returns(is_returns, 'weekly')
+    is_monthly = empyrical.aggregate_returns(is_returns, 'monthly')
     sns.boxplot(data=[is_returns, is_weekly, is_monthly],
                 palette=["#4c72B0", "#55A868", "#CCB974"],
                 ax=ax, **kwargs)
 
     if live_start_date is not None:
         oos_returns = returns.loc[returns.index >= live_start_date]
-        oos_weekly = qrisk.aggregate_returns(oos_returns, 'weekly')
-        oos_monthly = qrisk.aggregate_returns(oos_returns, 'monthly')
+        oos_weekly = empyrical.aggregate_returns(oos_returns, 'weekly')
+        oos_monthly = empyrical.aggregate_returns(oos_returns, 'monthly')
 
         sns.swarmplot(data=[oos_returns, oos_weekly, oos_monthly], ax=ax,
                       color="red",
@@ -1148,7 +1148,7 @@ def show_return_range(returns):
          - See full explanation in tears.create_full_tear_sheet.
     """
 
-    df_weekly = qrisk.aggregate_returns(returns, 'weekly')
+    df_weekly = empyrical.aggregate_returns(returns, 'weekly')
 
     two_sigma_daily = returns.mean() - 2 * returns.std()
     two_sigma_weekly = df_weekly.mean() - 2 * df_weekly.std()
@@ -1217,7 +1217,7 @@ def plot_turnover(returns, transactions, positions,
                'Average daily turnover, net'],
               loc=legend_loc)
     ax.set_title('Daily Turnover')
-    df_cum_rets = qrisk.cum_returns(returns, starting_value=1)
+    df_cum_rets = empyrical.cum_returns(returns, starting_value=1)
     ax.set_xlim((df_cum_rets.index[0], df_cum_rets.index[-1]))
     ax.set_ylim((0, 1))
     ax.set_ylabel('Turnover')
@@ -1265,7 +1265,7 @@ def plot_slippage_sweep(returns, transactions, positions,
     for bps in slippage_params:
         adj_returns = txn.adjust_returns_for_slippage(returns, turnover, bps)
         label = str(bps) + " bps"
-        slippage_sweep[label] = qrisk.cum_returns(adj_returns, 1)
+        slippage_sweep[label] = empyrical.cum_returns(adj_returns, 1)
 
     slippage_sweep.plot(alpha=1.0, lw=0.5, ax=ax)
 
@@ -1311,7 +1311,7 @@ def plot_slippage_sensitivity(returns, transactions, positions,
     avg_returns_given_slippage = pd.Series()
     for bps in range(1, 100):
         adj_returns = txn.adjust_returns_for_slippage(returns, turnover, bps)
-        avg_returns = qrisk.annual_return(adj_returns)
+        avg_returns = empyrical.annual_return(adj_returns)
         avg_returns_given_slippage.loc[bps] = avg_returns
 
     avg_returns_given_slippage.plot(alpha=1.0, lw=2, ax=ax)
@@ -1339,7 +1339,7 @@ def plot_capacity_sweep(returns, transactions, market_data,
                                                   txn_daily_w_bar,
                                                   start_pv,
                                                   bt_starting_capital)
-        sharpe = qrisk.sharpe_ratio(adj_ret)
+        sharpe = empyrical.sharpe_ratio(adj_ret)
         if sharpe < -1:
             break
         captial_base_sweep.loc[start_pv] = sharpe
@@ -1421,7 +1421,7 @@ def plot_daily_volume(returns, transactions, ax=None, **kwargs):
     ax.axhline(daily_txn.txn_shares.mean(), color='steelblue',
                linestyle='--', lw=3, alpha=1.0)
     ax.set_title('Daily Trading Volume')
-    df_cum_rets = qrisk.cum_returns(returns, starting_value=1)
+    df_cum_rets = empyrical.cum_returns(returns, starting_value=1)
     ax.set_xlim((df_cum_rets.index[0], df_cum_rets.index[-1]))
     ax.set_ylabel('Amount of shares traded')
     ax.set_xlabel('')
@@ -1515,7 +1515,7 @@ def plot_monthly_returns_timeseries(returns, ax=None, **kwargs):
     """
 
     def cumulate_returns(x):
-        return qrisk.cum_returns(x)[-1]
+        return empyrical.cum_returns(x)[-1]
 
     if ax is None:
         ax = plt.gca()
@@ -1719,7 +1719,7 @@ def plot_multistrike_cones(is_returns, oos_returns, num_samples=1000,
     else:
         axes = ax
 
-    returns = qrisk.cum_returns(oos_returns, starting_value=1.)
+    returns = empyrical.cum_returns(oos_returns, starting_value=1.)
     bounds = timeseries.forecast_cone_bootstrap(is_returns,
                                                 len(oos_returns),
                                                 cone_std=cone_std,

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -32,7 +32,7 @@ from . import capacity
 from . import plotting
 from . import _seaborn as sns
 from .plotting import plotting_context
-import qrisk
+import empyrical
 
 try:
     from . import bayesian
@@ -253,7 +253,7 @@ def create_returns_tear_sheet(returns, live_start_date=None,
         if returns.index[0] < benchmark_rets.index[0]:
             returns = returns[returns.index > benchmark_rets.index[0]]
 
-    df_cum_rets = qrisk.cum_returns(returns, starting_value=1)
+    df_cum_rets = empyrical.cum_returns(returns, starting_value=1)
     print("Entire data start date: " + str(df_cum_rets
                                            .index[0].strftime('%Y-%m-%d')))
     print("Entire data end date: " + str(df_cum_rets
@@ -694,9 +694,9 @@ def create_interesting_times_tear_sheet(
 
         # i=0 -> 0, i=1 -> 0, i=2 -> 1 ;; i=0 -> 0, i=1 -> 1, i=2 -> 0
         ax = plt.subplot(gs[int(i / 2.0), i % 2])
-        qrisk.cum_returns(rets_period).plot(
+        empyrical.cum_returns(rets_period).plot(
             ax=ax, color='forestgreen', label='algo', alpha=0.7, lw=2)
-        qrisk.cum_returns(bmark_interesting[name]).plot(
+        empyrical.cum_returns(bmark_interesting[name]).plot(
             ax=ax, color='gray', label='SPY', alpha=0.6)
         ax.legend(['algo',
                    'SPY'],

--- a/pyfolio/tests/test_timeseries.py
+++ b/pyfolio/tests/test_timeseries.py
@@ -265,7 +265,7 @@ class TestStats(TestCase):
             returns, rolling_sharpe_window).values.tolist()), expected)
 
     @parameterized.expand([
-        (simple_rets[:5], simple_benchmark[:5], 2, 8.024708101613483e-32)
+        (simple_rets[:5], simple_benchmark, 2, 8.024708101613483e-32)
     ])
     def test_beta(self, returns, benchmark_rets, rolling_window, expected):
         self.assertEqual(

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -28,11 +28,11 @@ from .utils import DAILY
 from .interesting_periods import PERIODS
 from .deprecate import deprecated
 
-import qrisk
+import empyrical
 
 DEPRECATION_WARNING = ("Risk functions in pyfolio.timeseries are deprecated "
                        "and will be removed in a future release. Please "
-                       "install the qrisk package instead.")
+                       "install the empyrical package instead.")
 
 
 def var_cov_var_normal(P, c, mu=0, sigma=1):
@@ -80,7 +80,7 @@ def max_drawdown(returns):
     See https://en.wikipedia.org/wiki/Drawdown_(economics) for more details.
     """
 
-    return qrisk.max_drawdown(returns)
+    return empyrical.max_drawdown(returns)
 
 
 @deprecated(msg=DEPRECATION_WARNING)
@@ -104,7 +104,7 @@ def annual_return(returns, period=DAILY):
 
     """
 
-    return qrisk.annual_return(returns, period=period)
+    return empyrical.annual_return(returns, period=period)
 
 
 @deprecated(msg=DEPRECATION_WARNING)
@@ -128,7 +128,7 @@ def annual_volatility(returns, period=DAILY):
         Annual volatility.
     """
 
-    return qrisk.annual_volatility(returns, period=period)
+    return empyrical.annual_volatility(returns, period=period)
 
 
 @deprecated(msg=DEPRECATION_WARNING)
@@ -157,7 +157,7 @@ def calmar_ratio(returns, period=DAILY):
     See https://en.wikipedia.org/wiki/Calmar_ratio for more details.
     """
 
-    return qrisk.calmar_ratio(returns, period=period)
+    return empyrical.calmar_ratio(returns, period=period)
 
 
 @deprecated(msg=DEPRECATION_WARNING)
@@ -194,7 +194,8 @@ def omega_ratio(returns, annual_return_threshhold=0.0):
 
     """
 
-    return qrisk.omega_ratio(returns, required_return=annual_return_threshhold)
+    return empyrical.omega_ratio(returns,
+                                 required_return=annual_return_threshhold)
 
 
 @deprecated(msg=DEPRECATION_WARNING)
@@ -224,7 +225,7 @@ def sortino_ratio(returns, required_return=0, period=DAILY):
 
     """
 
-    return qrisk.sortino_ratio(returns, required_return=required_return)
+    return empyrical.sortino_ratio(returns, required_return=required_return)
 
 
 @deprecated(msg=DEPRECATION_WARNING)
@@ -254,9 +255,9 @@ def downside_risk(returns, required_return=0, period=DAILY):
 
     """
 
-    return qrisk.downside_risk(returns,
-                               required_return=required_return,
-                               period=period)
+    return empyrical.downside_risk(returns,
+                                   required_return=required_return,
+                                   period=period)
 
 
 @deprecated(msg=DEPRECATION_WARNING)
@@ -289,7 +290,7 @@ def sharpe_ratio(returns, risk_free=0, period=DAILY):
 
     """
 
-    return qrisk.sharpe_ratio(returns, risk_free=risk_free, period=period)
+    return empyrical.sharpe_ratio(returns, risk_free=risk_free, period=period)
 
 
 @deprecated(msg=DEPRECATION_WARNING)
@@ -316,7 +317,7 @@ def information_ratio(returns, factor_returns):
 
     """
 
-    return qrisk.information_ratio(returns, factor_returns)
+    return empyrical.information_ratio(returns, factor_returns)
 
 
 @deprecated(msg=DEPRECATION_WARNING)
@@ -342,7 +343,7 @@ def alpha_beta(returns, factor_returns):
 
     """
 
-    return qrisk.alpha_beta(returns, factor_returns=factor_returns)
+    return empyrical.alpha_beta(returns, factor_returns=factor_returns)
 
 
 @deprecated(msg=DEPRECATION_WARNING)
@@ -365,7 +366,7 @@ def alpha(returns, factor_returns):
         Alpha.
     """
 
-    return qrisk.alpha(returns, factor_returns=factor_returns)
+    return empyrical.alpha(returns, factor_returns=factor_returns)
 
 
 @deprecated(msg=DEPRECATION_WARNING)
@@ -388,7 +389,7 @@ def beta(returns, factor_returns):
         Beta.
     """
 
-    return qrisk.beta(returns, factor_returns)
+    return empyrical.beta(returns, factor_returns)
 
 
 @deprecated(msg=DEPRECATION_WARNING)
@@ -410,7 +411,7 @@ def stability_of_timeseries(returns):
 
     """
 
-    return qrisk.stability_of_timeseries(returns)
+    return empyrical.stability_of_timeseries(returns)
 
 
 @deprecated(msg=DEPRECATION_WARNING)
@@ -433,7 +434,7 @@ def tail_ratio(returns):
 
     """
 
-    return qrisk.tail_ratio(returns)
+    return empyrical.tail_ratio(returns)
 
 
 def common_sense_ratio(returns):
@@ -456,7 +457,8 @@ def common_sense_ratio(returns):
         common sense ratio
 
     """
-    return qrisk.tail_ratio(returns) * (1 + qrisk.annual_return(returns))
+    return empyrical.tail_ratio(returns) * \
+        (1 + empyrical.annual_return(returns))
 
 
 SIMPLE_STAT_FUNCS = [
@@ -526,7 +528,7 @@ def cum_returns(returns, starting_value=0):
     where it is possible to sum instead of multiplying.
     """
 
-    return qrisk.cum_returns(returns, starting_value=starting_value)
+    return empyrical.cum_returns(returns, starting_value=starting_value)
 
 
 @deprecated(msg=DEPRECATION_WARNING)
@@ -548,7 +550,7 @@ def aggregate_returns(returns, convert_to):
         Aggregated returns.
     """
 
-    return qrisk.aggregate_returns(returns, convert_to=convert_to)
+    return empyrical.aggregate_returns(returns, convert_to=convert_to)
 
 
 def calc_multifactor(returns, factors):
@@ -614,9 +616,9 @@ def rolling_beta(returns, factor_returns,
         out = pd.Series(index=returns.index)
         for beg, end in zip(returns.index[0:-rolling_window],
                             returns.index[rolling_window:]):
-            out.loc[end] = qrisk.alpha_beta(
+            out.loc[end] = empyrical.beta(
                 returns.loc[beg:end],
-                factor_returns.loc[beg:end])[1]
+                factor_returns.loc[beg:end])
 
         return out
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ install_reqs = [
     'seaborn>=0.6.0',
     'pandas-datareader>=0.2',
     'scikit-learn>=0.17',
-    'qrisk>=0.1.3'
+    'empyrical==0.1.9'
 ]
 
 extras_reqs = {


### PR DESCRIPTION
The name of the risk library changed from qrisk to empyrical. This affected pyfolio in several places. 

An update in empyrical also requires function inputs (i.e. 'returns' and 'factor_returns') to have identical indexes. As a result, a test required an adjustment.

Example data has been rebuilt to reflect updated metrics. The affected columns are: treasury_period_return, sortino, beta, benchmark_volatility, benchmark_period_return, alpha, algorithm_period_return, algo_volatility.