### PR TITLE
Update empyrical to 0.1.11

### DIFF
--- a/pyfolio/tests/test_timeseries.py
+++ b/pyfolio/tests/test_timeseries.py
@@ -265,7 +265,7 @@ class TestStats(TestCase):
             returns, rolling_sharpe_window).values.tolist()), expected)
 
     @parameterized.expand([
-        (simple_rets[:5], simple_benchmark, 2, 8.024708101613483e-32)
+        (simple_rets[:5], simple_benchmark, 2, 8.177564888977994e-17)
     ])
     def test_beta(self, returns, benchmark_rets, rolling_window, expected):
         self.assertEqual(

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ install_reqs = [
     'seaborn>=0.6.0',
     'pandas-datareader>=0.2',
     'scikit-learn>=0.17',
-    'empyrical==0.1.9'
+    'empyrical==0.1.11'
 ]
 
 extras_reqs = {


### PR DESCRIPTION
Updates the version of empyrical to 0.1.11. This version fixes the incorrect beta calculation of the previous version.