### PR TITLE
BLD: Update empyrical to 0.1.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ install_reqs = [
     'seaborn>=0.6.0',
     'pandas-datareader>=0.2',
     'scikit-learn>=0.17',
-    'empyrical==0.1.9'
+    'empyrical==0.1.11'
 ]
 
 extras_reqs = {


### PR DESCRIPTION
The previous version of empyrical calculated beta incorrectly. This updates pyfolio to a newer version with revised beta.