### PR TITLE
BLD: pyfolio can use newer empyrical

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,12 @@ before_install:
 install:
   - conda create -q -n testenv --yes python=$TRAVIS_PYTHON_VERSION ipython pyzmq numpy scipy nose matplotlib pandas Cython patsy statsmodels flake8 scikit-learn seaborn runipy pytables networkx pandas-datareader matplotlib-tests joblib
   - source activate testenv
-  - pip install nose_parameterized empyrical>=0.1.9
+  - pip install nose_parameterized
   #- pip install --no-deps git+https://github.com/quantopian/zipline
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then conda install --yes mock enum34; fi
   - pip install --no-deps git+https://github.com/Theano/Theano.git@rel-0.8.1
   - pip install --no-deps git+https://github.com/pymc-devs/pymc3.git
-  - python setup.py build_ext --inplace
+  - pip install -e .[bayesian]
 
 before_script:
   - "flake8 pyfolio"

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ install_reqs = [
     'seaborn>=0.6.0',
     'pandas-datareader>=0.2',
     'scikit-learn>=0.17',
-    'empyrical==0.1.11'
+    'empyrical>=0.1.11',
 ]
 
 extras_reqs = {


### PR DESCRIPTION
Also don't need special install for empyrical on travis

We don't have any pyfolio C extensions, but when we do, pip installing pyfolio should include that.