### PR TITLE
BLD: Need correct param for setup to specify extra reqs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ install:
   - pip install nose_parameterized
   #- pip install --no-deps git+https://github.com/quantopian/zipline
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then conda install --yes mock enum34; fi
-  - pip install --no-deps git+https://github.com/Theano/Theano.git@rel-0.8.1
   - pip install --no-deps git+https://github.com/pymc-devs/pymc3.git
   - pip install -e .[bayesian]
 

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
         package_data={'pyfolio': ['data/*.*']},
         classifiers=classifiers,
         install_requires=install_reqs,
-        extras_requires=extras_reqs,
+        extras_require=extras_reqs,
         tests_require=test_reqs,
         test_suite='nose.collector',
     )


### PR DESCRIPTION
Otherwise, `$ pip install -e .[bayesian]` warns me:
"pyfolio 0.5.1+37.gb684c3a does not provide the extra 'bayesian'"

Also, Theano will get installed by pymc3 extra dependency