### PR TITLE
Cum returns final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ install:
   - pip install nose_parameterized
   #- pip install --no-deps git+https://github.com/quantopian/zipline
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then conda install --yes mock enum34; fi
-  - pip install --no-deps git+https://github.com/pymc-devs/pymc3.git
   - pip install -e .[bayesian]
 
 before_script:

--- a/pyfolio/tests/test_pos.py
+++ b/pyfolio/tests/test_pos.py
@@ -76,7 +76,6 @@ class PositionsTestCase(TestCase):
             index=index
         )
         expected.index.name = 'index'
-        expected.columns.name = 'sid'
 
         assert_frame_equal(result, expected)
 

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -462,6 +462,7 @@ def common_sense_ratio(returns):
 
 
 SIMPLE_STAT_FUNCS = [
+    empyrical.cum_returns_final,
     annual_return,
     annual_volatility,
     sharpe_ratio,

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ install_reqs = [
     'seaborn>=0.7.1',
     'pandas-datareader>=0.2',
     'scikit-learn>=0.17',
-    'empyrical>=0.1.11',
+    'empyrical>=0.2.1',
     'statsmodels>=0.6.1',
     'jsonschema>=2.5.1',
 ]


### PR DESCRIPTION
https://github.com/quantopian/qexec/issues/8187

In the backtester we display 'Total Returns' which is the last value of the cumulative returns. In pyfolio, calling `perf_stats(returns)` displays annual return, but not the total return. 