### PR TITLE
BUG: Fix misaligned indexes when redrawing cones

### DIFF
--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -724,7 +724,7 @@ def plot_rolling_returns(returns,
             is_returns = returns.loc[returns.index < live_start_date]
             cone_bounds = cone_function(
                 is_returns,
-                len(oos_cum_returns),
+                oos_cum_returns,
                 cone_std=cone_std,
                 starting_value=is_cum_returns[-1])
 
@@ -1724,6 +1724,8 @@ def plot_cones(name, bounds, oos_returns, num_samples=1000, ax=None,
     for c in range(num_strikes + 1):
         if c > 0:
             tmp = returns.loc[cone_start:]
+            bounds_tmp = bounds_tmp.iloc[0:len(tmp)]
+            bounds_tmp = bounds_tmp.set_index(tmp.index)
             crossing = (tmp < bounds_tmp[float(-2.)].iloc[:len(tmp)])
             if crossing.sum() <= 0:
                 break
@@ -1800,7 +1802,7 @@ def plot_multistrike_cones(is_returns, oos_returns, num_samples=1000,
     """
     bounds = timeseries.forecast_cone_bootstrap(
         is_returns=is_returns,
-        num_days=len(oos_returns),
+        oos_returns=oos_returns,
         cone_std=cone_std,
         num_samples=num_samples,
         random_seed=random_seed

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -1071,7 +1071,7 @@ def summarize_paths(samples, cone_std=(1., 1.5, 2.)):
     return cone_bounds
 
 
-def forecast_cone_bootstrap(is_returns, num_days, cone_std=(1., 1.5, 2.),
+def forecast_cone_bootstrap(is_returns, oos_returns, cone_std=(1., 1.5, 2.),
                             starting_value=1, num_samples=1000,
                             random_seed=None):
     """
@@ -1086,8 +1086,9 @@ def forecast_cone_bootstrap(is_returns, num_days, cone_std=(1., 1.5, 2.),
     is_returns : pd.Series
         In-sample daily returns of the strategy, noncumulative.
          - See full explanation in tears.create_full_tear_sheet.
-    num_days : int
-        Number of days to project the probability cone forward.
+    oos_returns : pd.Series
+        Out-of-sample daily returns of the strategy, noncumulative.
+         - See full explanation in tears.create_full_tear_sheet.
     cone_std : int, float, or list of int/float
         Number of standard devations to use in the boundaries of
         the cone. If multiple values are passed, cone bounds will
@@ -1114,7 +1115,7 @@ def forecast_cone_bootstrap(is_returns, num_days, cone_std=(1., 1.5, 2.),
 
     samples = simulate_paths(
         is_returns=is_returns,
-        num_days=num_days,
+        num_days=len(oos_returns),
         starting_value=starting_value,
         num_samples=num_samples,
         random_seed=random_seed
@@ -1125,7 +1126,7 @@ def forecast_cone_bootstrap(is_returns, num_days, cone_std=(1., 1.5, 2.),
         cone_std=cone_std
     )
 
-    return cone_bounds
+    return cone_bounds.set_index(oos_returns.index)
 
 
 def extract_interesting_date_ranges(returns):


### PR DESCRIPTION
Indices must be equal. This PR adds a datetime index to `bounds` and updates the value of `bounds_tmp` to be the same as `tmp`. Those two variables change value as a new cone is redrawn.