### PR TITLE
Add transaction times plot, fix strings, and new round trip lifetimes plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ financial portfolios developed by
 At the core of pyfolio is a so-called tear sheet that consists of
 various individual plots that provide a comprehensive image of the
 performance of a trading algorithm. Here's an example tear sheet, which comes from the Zipline algorithm sample notebook:
+
 ![example tear 0](https://github.com/quantopian/pyfolio/raw/master/docs/example_tear_0.png "Example tear sheet created from a Zipline algo")
 ![example tear 1](https://github.com/quantopian/pyfolio/raw/master/docs/example_tear_1.png "Example tear sheet created from a Zipline algo")
 ![example tear 2](https://github.com/quantopian/pyfolio/raw/master/docs/example_tear_2.png)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ financial portfolios developed by
 
 At the core of pyfolio is a so-called tear sheet that consists of
 various individual plots that provide a comprehensive image of the
-performance of a trading algorithm. Here is an example of a tear sheet of a the Zipline algo included as one of our example notebooks:
+performance of a trading algorithm. Here's an example tear sheet, which comes from the Zipline algorithm sample notebook:
 ![example tear 0](https://github.com/quantopian/pyfolio/raw/master/docs/example_tear_0.png "Example tear sheet created from a Zipline algo")
 ![example tear 1](https://github.com/quantopian/pyfolio/raw/master/docs/example_tear_1.png "Example tear sheet created from a Zipline algo")
 ![example tear 2](https://github.com/quantopian/pyfolio/raw/master/docs/example_tear_2.png)

--- a/pyfolio/bayesian.py
+++ b/pyfolio/bayesian.py
@@ -34,7 +34,8 @@ from empyrical import cum_returns
 
 
 def model_returns_t_alpha_beta(data, bmark, samples=2000):
-    """Run Bayesian alpha-beta-model with T distributed returns.
+    """
+    Run Bayesian alpha-beta-model with T distributed returns.
 
     This model estimates intercept (alpha) and slope (beta) of two
     return sets. Usually, these will be algorithm returns and
@@ -64,6 +65,7 @@ def model_returns_t_alpha_beta(data, bmark, samples=2000):
         A PyMC3 trace object that contains samples for each parameter
         of the posterior.
     """
+
     if data.shape[0] != bmark.shape[0]:
         data = pd.Series(data, index=bmark.index)
 
@@ -106,7 +108,8 @@ def model_returns_t_alpha_beta(data, bmark, samples=2000):
 
 
 def model_returns_normal(data, samples=500):
-    """Run Bayesian model assuming returns are normally distributed.
+    """
+    Run Bayesian model assuming returns are normally distributed.
 
     Parameters
     ----------
@@ -122,8 +125,8 @@ def model_returns_normal(data, samples=500):
     trace : pymc3.sampling.BaseTrace object
         A PyMC3 trace object that contains samples for each parameter
         of the posterior.
-
     """
+
     with pm.Model() as model:
         mu = pm.Normal('mean returns', mu=0, sd=.01, testval=data.mean())
         sigma = pm.HalfCauchy('volatility', beta=1, testval=data.std())
@@ -145,7 +148,8 @@ def model_returns_normal(data, samples=500):
 
 
 def model_returns_t(data, samples=500):
-    """Run Bayesian model assuming returns are Student-T distributed.
+    """
+    Run Bayesian model assuming returns are Student-T distributed.
 
     Compared with the normal model, this model assumes returns are
     T-distributed and thus have a 3rd parameter (nu) that controls the
@@ -165,7 +169,6 @@ def model_returns_t(data, samples=500):
     trace : pymc3.sampling.BaseTrace object
         A PyMC3 trace object that contains samples for each parameter
         of the posterior.
-
     """
 
     with pm.Model() as model:
@@ -189,7 +192,8 @@ def model_returns_t(data, samples=500):
 
 
 def model_best(y1, y2, samples=1000):
-    """Bayesian Estimation Supersedes the T-Test
+    """
+    Bayesian Estimation Supersedes the T-Test
 
     This model runs a Bayesian hypothesis comparing if y1 and y2 come
     from the same distribution. Returns are assumed to be T-distributed.
@@ -276,7 +280,8 @@ def model_best(y1, y2, samples=1000):
 
 def plot_best(trace=None, data_train=None, data_test=None,
               samples=1000, burn=200, axs=None):
-    """Plot BEST significance analysis.
+    """
+    Plot BEST significance analysis.
 
     Parameters
     ----------
@@ -305,6 +310,7 @@ def plot_best(trace=None, data_train=None, data_test=None,
     --------
     model_best : Estimation of BEST model.
     """
+
     if trace is None:
         if (data_train is not None) or (data_test is not None):
             raise ValueError('Either pass trace or data_train and data_test')
@@ -364,7 +370,8 @@ def plot_best(trace=None, data_train=None, data_test=None,
 
 
 def model_stoch_vol(data, samples=2000):
-    """Run stochastic volatility model.
+    """
+    Run stochastic volatility model.
 
     This model estimates the volatility of a returns series over time.
     Returns are assumed to be T-distributed. lambda (width of
@@ -389,6 +396,7 @@ def model_stoch_vol(data, samples=2000):
     --------
     plot_stoch_vol : plotting of tochastic volatility model
     """
+
     from pymc3.distributions.timeseries import GaussianRandomWalk
 
     with pm.Model() as model:
@@ -412,7 +420,8 @@ def model_stoch_vol(data, samples=2000):
 
 
 def plot_stoch_vol(data, trace=None, ax=None):
-    """Generate plot for stochastic volatility model.
+    """
+    Generate plot for stochastic volatility model.
 
     Parameters
     ----------
@@ -432,6 +441,7 @@ def plot_stoch_vol(data, trace=None, ax=None):
     --------
     model_stoch_vol : run stochastic volatility model
     """
+
     if trace is None:
         trace = model_stoch_vol(data)
 
@@ -447,7 +457,8 @@ def plot_stoch_vol(data, trace=None, ax=None):
 
 
 def compute_bayes_cone(preds, starting_value=1.):
-    """Compute 5, 25, 75 and 95 percentiles of cumulative returns, used
+    """
+    Compute 5, 25, 75 and 95 percentiles of cumulative returns, used
     for the Bayesian cone.
 
     Parameters
@@ -463,7 +474,6 @@ def compute_bayes_cone(preds, starting_value=1.):
     dict of percentiles over time
         Dictionary mapping percentiles (5, 25, 75, 95) to a
         timeseries.
-
     """
 
     def scoreatpercentile(cum_preds, p):
@@ -477,7 +487,8 @@ def compute_bayes_cone(preds, starting_value=1.):
 
 
 def compute_consistency_score(returns_test, preds):
-    """Compute Bayesian consistency score.
+    """
+    Compute Bayesian consistency score.
 
     Parameters
     ----------
@@ -493,6 +504,7 @@ def compute_consistency_score(returns_test, preds):
         Bayesian cone spanned by preds) to 0 (returns_test completely
         outside of Bayesian cone.)
     """
+
     returns_test_cum = cum_returns(returns_test, starting_value=1.)
     cum_preds = np.cumprod(preds + 1, 1)
 
@@ -542,7 +554,8 @@ def _plot_bayes_cone(returns_train, returns_test,
 
 def run_model(model, returns_train, returns_test=None,
               bmark=None, samples=500, ppc=False):
-    """Run one of the Bayesian models.
+    """
+    Run one of the Bayesian models.
 
     Parameters
     ----------
@@ -574,8 +587,7 @@ def run_model(model, returns_train, returns_test=None,
 
     ppc : numpy.array (if ppc==True)
        PPC of shape samples x len(returns_test).
-
-"""
+    """
 
     if model == 'alpha_beta':
         model, trace = model_returns_t_alpha_beta(returns_train,
@@ -601,7 +613,8 @@ def run_model(model, returns_train, returns_test=None,
 
 def plot_bayes_cone(returns_train, returns_test, ppc,
                     plot_train_len=50, ax=None):
-    """Generate cumulative returns plot with Bayesian cone.
+    """
+    Generate cumulative returns plot with Bayesian cone.
 
     Parameters
     ----------
@@ -627,8 +640,7 @@ def plot_bayes_cone(returns_train, returns_test, ppc,
     trace : pymc3.sampling.BaseTrace
         A PyMC3 trace object that contains samples for each parameter
         of the posterior.
-
-"""
+    """
 
     score = compute_consistency_score(returns_test,
                                       ppc)

--- a/pyfolio/capacity.py
+++ b/pyfolio/capacity.py
@@ -27,6 +27,7 @@ def daily_txns_with_bar_data(transactions, market_data):
         price and volume columns for close price and daily volume for
         the corresponding ticker, respectively.
     """
+
     transactions.index.name = 'date'
     txn_daily = pd.DataFrame(transactions.assign(
         amount=abs(transactions.amount)).groupby(
@@ -43,7 +44,8 @@ def days_to_liquidate_positions(positions, market_data,
                                 max_bar_consumption=0.2,
                                 capital_base=1e6,
                                 mean_volume_window=5):
-    """Compute the number of days that would have been required
+    """
+    Compute the number of days that would have been required
     to fully liquidate each position on each day based on the
     trailing n day mean daily bar volume and a limit on the proportion
     of a daily bar that we are allowed to consume.
@@ -77,7 +79,6 @@ def days_to_liquidate_positions(positions, market_data,
     days_to_liquidate : pd.DataFrame
         Number of days required to fully liquidate daily positions.
         Datetime index, symbols as columns.
-
     """
 
     DV = market_data['volume'] * market_data['price']
@@ -128,7 +129,6 @@ def get_max_days_to_liquidate_by_ticker(positions, market_data,
         Max Number of days required to fully liquidate each traded name.
         Index of symbols. Columns for days_to_liquidate and the corresponding
         date and position_alloc on that day.
-
     """
 
     dtlp = days_to_liquidate_positions(positions, market_data,
@@ -171,8 +171,8 @@ def get_low_liquidity_transactions(transactions, market_data,
         the passed positions DataFrame (same dates and symbols).
     last_n_days : integer
         Compute for only the last n days of the passed backtest data.
-
     """
+
     txn_daily_w_bar = daily_txns_with_bar_data(transactions, market_data)
     txn_daily_w_bar.index.name = 'date'
     txn_daily_w_bar = txn_daily_w_bar.reset_index()
@@ -218,6 +218,7 @@ def apply_slippage_penalty(returns, txn_daily, simulate_starting_capital,
     adj_returns : pd.Series
         Slippage penalty adjusted daily returns.
     """
+
     mult = simulate_starting_capital / backtest_starting_capital
     simulate_traded_shares = abs(mult * txn_daily.amount)
     simulate_traded_dollars = txn_daily.price * simulate_traded_shares
@@ -226,7 +227,7 @@ def apply_slippage_penalty(returns, txn_daily, simulate_starting_capital,
     penalties = simulate_pct_volume_used**2 \
         * impact * simulate_traded_dollars
 
-    daily_penalty = penalties.resample('D', how='sum')
+    daily_penalty = penalties.resample('D').sum()
     daily_penalty = daily_penalty.reindex(returns.index).fillna(0)
 
     # Since we are scaling the numerator of the penalties linearly

--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -1574,7 +1574,8 @@ def plot_monthly_returns_timeseries(returns, ax=None, **kwargs):
     if ax is None:
         ax = plt.gca()
 
-    monthly_rets = returns.resample('M').cumulate_returns().to_period()
+    monthly_rets = returns.resample('M').apply(lambda x: cumulate_returns(x))
+    monthly_rets = monthly_rets.to_period()
 
     sns.barplot(x=monthly_rets.index,
                 y=monthly_rets.values,

--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -1656,7 +1656,7 @@ def plot_round_trip_lifetimes(round_trips, disp_amount=12, linewidth=24, ax=None
     ax.set_yticks(range(disp_amount))
     ax.set_yticklabels(symbols)
 
-    ax.set_ylim((-0.5, disp_amount-0.5))
+    ax.set_ylim((-0.5, min(len(symbols), disp_amount) - 0.5))
     red_box = patches.Rectangle([0, 0], 1, 1, color='r', label='Short')
     blue_box = patches.Rectangle([0, 0], 1, 1, color='b', label='Long')
     leg = ax.legend(handles=[red_box, blue_box], frameon=True, loc='lower left')

--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -42,6 +42,7 @@ from .utils import (APPROX_BDAYS_PER_MONTH,
 from functools import wraps
 import empyrical
 
+
 def plotting_context(func):
     """
     Decorator to set plotting context during function call.
@@ -1488,11 +1489,14 @@ def plot_txn_time_hist(transactions, bin_minutes=5, tz='America/New_York',
     txn_time.index = (txn_time.index/bin_minutes).astype(int) * bin_minutes
     txn_time = txn_time.groupby(level=0).sum()
 
-    txn_time['time_str'] = txn_time.index.map(lambda x: str(datetime.time(int(x/60), x%60))[:-3])
-    txn_time.trade_value = txn_time.trade_value.fillna(0) / txn_time.trade_value.sum()
+    txn_time['time_str'] = txn_time.index.map(lambda x: \
+                                              str(datetime.time(int(x/60),
+                                                                x%60))[:-3])
+    txn_time.trade_value = txn_time.trade_value.fillna(0) \
+                           / txn_time.trade_value.sum()
 
     ax.bar(txn_time.index, txn_time.trade_value, width=bin_minutes, **kwargs)
-    
+
     ax.set_xlim(570, 960)
     ax.set_xticks(txn_time.index[::int(30/bin_minutes)])
     ax.set_xticklabels(txn_time.time_str[::int(30/bin_minutes)])
@@ -1618,7 +1622,7 @@ def plot_monthly_returns_timeseries(returns, ax=None, **kwargs):
     return ax
 
 
-def plot_round_trip_lifetimes(round_trips, disp_amount=12, linewidth=24, ax=None):
+def plot_round_trip_lifetimes(round_trips, disp_amount=12, lsize=24, ax=None):
     """
     Plots timespans and directions of round trip trades.
 
@@ -1651,15 +1655,16 @@ def plot_round_trip_lifetimes(round_trips, disp_amount=12, linewidth=24, ax=None
             c = 'b' if row.long else 'r'
             y_ix = symbol_idx[symbol] + 0.05
             ax.plot([row['open_dt'], row['close_dt']],
-                    [y_ix, y_ix], color=c, linewidth=linewidth, solid_capstyle='butt')
+                    [y_ix, y_ix], color=c,
+                    linewidth=lsize, solid_capstyle='butt')
 
     ax.set_yticks(range(disp_amount))
     ax.set_yticklabels(symbols)
 
     ax.set_ylim((-0.5, min(len(symbols), disp_amount) - 0.5))
-    red_box = patches.Rectangle([0, 0], 1, 1, color='r', label='Short')
-    blue_box = patches.Rectangle([0, 0], 1, 1, color='b', label='Long')
-    leg = ax.legend(handles=[red_box, blue_box], frameon=True, loc='lower left')
+    blue = patches.Rectangle([0, 0], 1, 1, color='b', label='Long')
+    red = patches.Rectangle([0, 0], 1, 1, color='r', label='Short')
+    leg = ax.legend(handles=[blue, red], frameon=True, loc='lower left')
     leg.get_frame().set_edgecolor('black')
     ax.grid(False)
 

--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -25,7 +25,7 @@ import pytz
 import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.ticker import FuncFormatter
-import matplotlib.lines as mlines
+import matplotlib.patches as patches
 from matplotlib import figure
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 
@@ -1618,7 +1618,7 @@ def plot_monthly_returns_timeseries(returns, ax=None, **kwargs):
     return ax
 
 
-def plot_round_trip_lifetimes(round_trips, top=10, ax=None):
+def plot_round_trip_lifetimes(round_trips, disp_amount=12, linewidth=24, ax=None):
     """
     Plots timespans and directions of round trip trades.
 
@@ -1640,7 +1640,7 @@ def plot_round_trip_lifetimes(round_trips, top=10, ax=None):
         ax = plt.subplot()
 
     durations = round_trips.groupby('symbol').duration.apply(np.sum)
-    top_symbols = durations.sort_values(ascending=False).index[:10]
+    top_symbols = durations.sort_values(ascending=False).index[:disp_amount]
     top_round_trips = round_trips.copy()[round_trips.symbol.isin(top_symbols)]
 
     symbols = top_round_trips.symbol.unique()
@@ -1649,16 +1649,19 @@ def plot_round_trip_lifetimes(round_trips, top=10, ax=None):
     for symbol, sym_round_trips in top_round_trips.groupby('symbol'):
         for _, row in sym_round_trips.iterrows():
             c = 'b' if row.long else 'r'
-            y_ix = symbol_idx[symbol]
+            y_ix = symbol_idx[symbol] + 0.05
             ax.plot([row['open_dt'], row['close_dt']],
-                    [y_ix, y_ix], color=c)
+                    [y_ix, y_ix], color=c, linewidth=linewidth, solid_capstyle='butt')
 
-    ax.set_xticks(range(10))
+    ax.set_yticks(range(disp_amount))
     ax.set_yticklabels(symbols)
 
-    red_line = mlines.Line2D([], [], color='r', label='Short')
-    blue_line = mlines.Line2D([], [], color='b', label='Long')
-    ax.legend(handles=[red_line, blue_line], loc=0)
+    ax.set_ylim((-0.5, disp_amount-0.5))
+    red_box = patches.Rectangle([0, 0], 1, 1, color='r', label='Short')
+    blue_box = patches.Rectangle([0, 0], 1, 1, color='b', label='Long')
+    leg = ax.legend(handles=[red_box, blue_box], frameon=True, loc='lower left')
+    leg.get_frame().set_edgecolor('black')
+    ax.grid(False)
 
     return ax
 

--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -43,7 +43,10 @@ from functools import wraps
 import empyrical
 
 def plotting_context(func):
-    """Decorator to set plotting context during function call."""
+    """
+    Decorator to set plotting context during function call.
+    """
+
     @wraps(func)
     def call_w_context(*args, **kwargs):
         set_context = kwargs.pop('set_context', True)
@@ -56,7 +59,8 @@ def plotting_context(func):
 
 
 def context(context='notebook', font_scale=1.5, rc=None):
-    """Create pyfolio default plotting style context.
+    """
+    Create pyfolio default plotting style context.
 
     Under the hood, calls and returns seaborn.plotting_context() with
     some custom settings. Usually you would use in a with-context.
@@ -87,8 +91,8 @@ def context(context='notebook', font_scale=1.5, rc=None):
     See also
     --------
     For more information, see seaborn.plotting_context().
+    """
 
-"""
     if rc is None:
         rc = {}
 
@@ -110,7 +114,8 @@ def plot_rolling_fama_french(
         rolling_window=APPROX_BDAYS_PER_MONTH * 6,
         legend_loc='best',
         ax=None, **kwargs):
-    """Plots rolling Fama-French single factor betas.
+    """
+    Plots rolling Fama-French single factor betas.
 
     Specifically, plots SMB, HML, and UMD vs. date with a legend.
 
@@ -135,7 +140,6 @@ def plot_rolling_fama_french(
     -------
     ax : matplotlib.Axes
         The axes that were plotted on.
-
     """
 
     if ax is None:
@@ -316,7 +320,8 @@ def plot_monthly_returns_dist(returns, ax=None, **kwargs):
 
 
 def plot_holdings(returns, positions, legend_loc='best', ax=None, **kwargs):
-    """Plots total amount of stocks with an active position, either short
+    """
+    Plots total amount of stocks with an active position, either short
     or long.
 
     Displays daily total, daily average per month, and all-time daily
@@ -429,7 +434,8 @@ def plot_drawdown_periods(returns, top=10, ax=None, **kwargs):
 
 
 def plot_drawdown_underwater(returns, ax=None, **kwargs):
-    """Plots how far underwaterr returns are over time, or plots current
+    """
+    Plots how far underwaterr returns are over time, or plots current
     drawdown vs. date.
 
     Parameters
@@ -446,7 +452,6 @@ def plot_drawdown_underwater(returns, ax=None, **kwargs):
     -------
     ax : matplotlib.Axes
         The axes that were plotted on.
-
     """
 
     if ax is None:
@@ -466,7 +471,8 @@ def plot_drawdown_underwater(returns, ax=None, **kwargs):
 
 
 def plot_perf_stats(returns, factor_returns, ax=None):
-    """Create box plot of some performance metrics of the strategy.
+    """
+    Create box plot of some performance metrics of the strategy.
     The width of the box whiskers is determined by a bootstrap.
 
     Parameters
@@ -484,8 +490,8 @@ def plot_perf_stats(returns, factor_returns, ax=None):
     -------
     ax : matplotlib.Axes
         The axes that were plotted on.
-
     """
+
     if ax is None:
         ax = plt.gca()
 
@@ -501,7 +507,8 @@ def plot_perf_stats(returns, factor_returns, ax=None):
 
 def show_perf_stats(returns, factor_returns, gross_lev=None,
                     live_start_date=None, bootstrap=False):
-    """Prints some performance metrics of the strategy.
+    """
+    Prints some performance metrics of the strategy.
 
     - Shows amount of time the strategy has been run in backtest and
       out-of-sample (in live trading).
@@ -524,7 +531,6 @@ def show_perf_stats(returns, factor_returns, gross_lev=None,
         Whether to perform bootstrap analysis for the performance
         metrics.
          - For more information, see timeseries.perf_stats_bootstrap
-
     """
 
     if bootstrap:
@@ -606,7 +612,6 @@ def plot_returns(returns,
     -------
     ax : matplotlib.Axes
         The axes that were plotted on.
-
     """
 
     if ax is None:
@@ -685,8 +690,8 @@ def plot_rolling_returns(returns,
     -------
     ax : matplotlib.Axes
         The axes that were plotted on.
-
     """
+
     if ax is None:
         ax = plt.gca()
 
@@ -857,7 +862,8 @@ def plot_rolling_sharpe(returns, rolling_window=APPROX_BDAYS_PER_MONTH * 6,
 
 
 def plot_gross_leverage(returns, gross_lev, ax=None, **kwargs):
-    """Plots gross leverage versus date.
+    """
+    Plots gross leverage versus date.
 
     Gross leverage is the sum of long and short exposure per share
     divided by net asset value.
@@ -879,8 +885,7 @@ def plot_gross_leverage(returns, gross_lev, ax=None, **kwargs):
     -------
     ax : matplotlib.Axes
         The axes that were plotted on.
-
-"""
+    """
 
     if ax is None:
         ax = plt.gca()
@@ -898,7 +903,8 @@ def plot_gross_leverage(returns, gross_lev, ax=None, **kwargs):
 
 
 def plot_exposures(returns, positions_alloc, ax=None, **kwargs):
-    """Plots a cake chart of the long and short exposure.
+    """
+    Plots a cake chart of the long and short exposure.
 
     Parameters
     ----------
@@ -937,7 +943,8 @@ def show_and_plot_top_positions(returns, positions_alloc,
                                 show_and_plot=2, hide_positions=False,
                                 legend_loc='real_best', ax=None,
                                 **kwargs):
-    """Prints and/or plots the exposures of the top 10 held positions of
+    """
+    Prints and/or plots the exposures of the top 10 held positions of
     all time.
 
     Parameters
@@ -1037,6 +1044,7 @@ def plot_max_median_position_concentration(positions, ax=None, **kwargs):
     ax : matplotlib.Axes
         The axes that were plotted on.
     """
+
     if ax is None:
         ax = plt.gcf()
 
@@ -1052,7 +1060,8 @@ def plot_max_median_position_concentration(positions, ax=None, **kwargs):
 
 
 def plot_sector_allocations(returns, sector_alloc, ax=None, **kwargs):
-    """Plots the sector exposures of the portfolio over time.
+    """
+    Plots the sector exposures of the portfolio over time.
 
     Parameters
     ----------
@@ -1071,6 +1080,7 @@ def plot_sector_allocations(returns, sector_alloc, ax=None, **kwargs):
     ax : matplotlib.Axes
         The axes that were plotted on.
     """
+
     if ax is None:
         ax = plt.gcf()
 
@@ -1093,7 +1103,8 @@ def plot_sector_allocations(returns, sector_alloc, ax=None, **kwargs):
 
 
 def plot_return_quantiles(returns, live_start_date=None, ax=None, **kwargs):
-    """Creates a box plot of daily, weekly, and monthly return
+    """
+    Creates a box plot of daily, weekly, and monthly return
     distributions.
 
     Parameters
@@ -1113,7 +1124,6 @@ def plot_return_quantiles(returns, live_start_date=None, ax=None, **kwargs):
     -------
     ax : matplotlib.Axes
         The axes that were plotted on.
-
     """
 
     if ax is None:
@@ -1170,7 +1180,8 @@ def show_return_range(returns):
 
 def plot_turnover(returns, transactions, positions,
                   legend_loc='best', ax=None, **kwargs):
-    """Plots turnover vs. date.
+    """
+    Plots turnover vs. date.
 
     Turnover is the number of shares traded for a period as a fraction
     of total shares.
@@ -1200,7 +1211,6 @@ def plot_turnover(returns, transactions, positions,
     -------
     ax : matplotlib.Axes
         The axes that were plotted on.
-
     """
 
     if ax is None:
@@ -1235,7 +1245,8 @@ def plot_turnover(returns, transactions, positions,
 def plot_slippage_sweep(returns, transactions, positions,
                         slippage_params=(3, 8, 10, 12, 15, 20, 50),
                         ax=None, **kwargs):
-    """Plots a equity curves at different per-dollar slippage assumptions.
+    """
+    Plots a equity curves at different per-dollar slippage assumptions.
 
     Parameters
     ----------
@@ -1260,8 +1271,8 @@ def plot_slippage_sweep(returns, transactions, positions,
     -------
     ax : matplotlib.Axes
         The axes that were plotted on.
-
     """
+
     if ax is None:
         ax = plt.gca()
 
@@ -1286,7 +1297,8 @@ def plot_slippage_sweep(returns, transactions, positions,
 
 def plot_slippage_sensitivity(returns, transactions, positions,
                               ax=None, **kwargs):
-    """Plots curve relating per-dollar slippage to average annual returns.
+    """
+    Plots curve relating per-dollar slippage to average annual returns.
 
     Parameters
     ----------
@@ -1308,8 +1320,8 @@ def plot_slippage_sensitivity(returns, transactions, positions,
     -------
     ax : matplotlib.Axes
         The axes that were plotted on.
-
     """
+
     if ax is None:
         ax = plt.gca()
 
@@ -1365,7 +1377,8 @@ def plot_capacity_sweep(returns, transactions, market_data,
 
 def plot_daily_turnover_hist(transactions, positions,
                              ax=None, **kwargs):
-    """Plots a histogram of daily turnover rates.
+    """
+    Plots a histogram of daily turnover rates.
 
     Parameters
     ----------
@@ -1384,7 +1397,6 @@ def plot_daily_turnover_hist(transactions, positions,
     -------
     ax : matplotlib.Axes
         The axes that were plotted on.
-
     """
 
     if ax is None:
@@ -1397,7 +1409,8 @@ def plot_daily_turnover_hist(transactions, positions,
 
 
 def plot_daily_volume(returns, transactions, ax=None, **kwargs):
-    """Plots trading volume per day vs. date.
+    """
+    Plots trading volume per day vs. date.
 
     Also displays all-time daily average.
 
@@ -1418,7 +1431,6 @@ def plot_daily_volume(returns, transactions, ax=None, **kwargs):
     -------
     ax : matplotlib.Axes
         The axes that were plotted on.
-
     """
 
     if ax is None:
@@ -1436,7 +1448,8 @@ def plot_daily_volume(returns, transactions, ax=None, **kwargs):
 
 def plot_txn_time_hist(transactions, bin_minutes=5, tz='America/New_York',
                        ax=None, **kwargs):
-    """Plots a histogram of transaction times, binning the times into
+    """
+    Plots a histogram of transaction times, binning the times into
     buckets of a given duration.
 
     Parameters
@@ -1489,7 +1502,8 @@ def plot_txn_time_hist(transactions, bin_minutes=5, tz='America/New_York',
 
 def plot_daily_returns_similarity(returns_backtest, returns_live,
                                   title='', ax=None, **kwargs):
-    """Plots overlapping distributions of in-sample (backtest) returns
+    """
+    Plots overlapping distributions of in-sample (backtest) returns
     and out-of-sample (live trading) returns.
 
     Parameters
@@ -1509,7 +1523,6 @@ def plot_daily_returns_similarity(returns_backtest, returns_live,
     -------
     ax : matplotlib.Axes
         The axes that were plotted on.
-
     """
 
     if ax is None:
@@ -1527,7 +1540,8 @@ def plot_daily_returns_similarity(returns_backtest, returns_live,
 
 
 def show_worst_drawdown_periods(returns, top=5):
-    """Prints information about the worst drawdown periods.
+    """
+    Prints information about the worst drawdown periods.
 
     Prints peak dates, valley dates, recovery dates, and net
     drawdowns.
@@ -1539,7 +1553,6 @@ def show_worst_drawdown_periods(returns, top=5):
          - See full explanation in tears.create_full_tear_sheet.
     top : int, optional
         Amount of top drawdowns periods to plot (default 5).
-
     """
 
     drawdown_df = timeseries.gen_drawdown_table(returns, top=top)
@@ -1621,6 +1634,7 @@ def plot_round_trip_life_times(round_trips, ax=None):
     ax : matplotlib.Axes
         The axes that were plotted on.
     """
+
     if ax is None:
         ax = plt.subplot()
 
@@ -1767,6 +1781,7 @@ def plot_cones(name, bounds, oos_returns, num_samples=1000, ax=None,
     fig : matplotlib.figure
         The figure instance which contains all the plot elements.
     """
+
     if ax is None:
         fig = figure.Figure(figsize=(10, 8))
         FigureCanvasAgg(fig)
@@ -1859,6 +1874,7 @@ def plot_multistrike_cones(is_returns, oos_returns, num_samples=1000,
     fig : matplotlib.figure
         The figure instance which contains all the plot elements.
     """
+
     bounds = timeseries.forecast_cone_bootstrap(
         is_returns=is_returns,
         num_days=len(oos_returns),

--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -1489,11 +1489,12 @@ def plot_txn_time_hist(transactions, bin_minutes=5, tz='America/New_York',
     txn_time.index = (txn_time.index/bin_minutes).astype(int) * bin_minutes
     txn_time = txn_time.groupby(level=0).sum()
 
-    txn_time['time_str'] = txn_time.index.map(lambda x: \
+    txn_time['time_str'] = txn_time.index.map(lambda x:
                                               str(datetime.time(int(x/60),
-                                                                x%60))[:-3])
-    txn_time.trade_value = txn_time.trade_value.fillna(0) \
-                           / txn_time.trade_value.sum()
+                                                                x % 60))[:-3])
+
+    trade_value_sum = txn_time.trade_value.sum()
+    txn_time.trade_value = txn_time.trade_value.fillna(0) / trade_value_sum
 
     ax.bar(txn_time.index, txn_time.trade_value, width=bin_minutes, **kwargs)
 

--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -1618,7 +1618,7 @@ def plot_monthly_returns_timeseries(returns, ax=None, **kwargs):
     return ax
 
 
-def plot_round_trip_life_times(round_trips, ax=None):
+def plot_round_trip_lifetimes(round_trips, top=10, ax=None):
     """
     Plots timespans and directions of round trip trades.
 
@@ -1639,16 +1639,21 @@ def plot_round_trip_life_times(round_trips, ax=None):
     if ax is None:
         ax = plt.subplot()
 
-    symbols = round_trips.symbol.unique()
+    durations = round_trips.groupby('symbol').duration.apply(np.sum)
+    top_symbols = durations.sort_values(ascending=False).index[:10]
+    top_round_trips = round_trips.copy()[round_trips.symbol.isin(top_symbols)]
+
+    symbols = top_round_trips.symbol.unique()
     symbol_idx = pd.Series(np.arange(len(symbols)), index=symbols)
 
-    for symbol, sym_round_trips in round_trips.groupby('symbol'):
+    for symbol, sym_round_trips in top_round_trips.groupby('symbol'):
         for _, row in sym_round_trips.iterrows():
             c = 'b' if row.long else 'r'
             y_ix = symbol_idx[symbol]
             ax.plot([row['open_dt'], row['close_dt']],
                     [y_ix, y_ix], color=c)
 
+    ax.set_xticks(range(10))
     ax.set_yticklabels(symbols)
 
     red_line = mlines.Line2D([], [], color='r', label='Short')

--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -146,12 +146,12 @@ def plot_rolling_fama_french(
         ax = plt.gca()
 
     ax.set_title(
-        "Rolling Fama-French Single Factor Betas (%.0f-month)" % (
+        "Rolling Fama-French single factor betas (%.0f-month)" % (
             rolling_window / APPROX_BDAYS_PER_MONTH
         )
     )
 
-    ax.set_ylabel('beta')
+    ax.set_ylabel('Beta')
 
     rolling_beta = timeseries.rolling_fama_french(
         returns,
@@ -214,7 +214,7 @@ def plot_monthly_returns_heatmap(returns, ax=None, **kwargs):
         ax=ax, **kwargs)
     ax.set_ylabel('Year')
     ax.set_xlabel('Month')
-    ax.set_title("Monthly Returns (%)")
+    ax.set_title("Monthly returns (%)")
     return ax
 
 
@@ -263,7 +263,7 @@ def plot_annual_returns(returns, ax=None, **kwargs):
 
     ax.set_ylabel('Year')
     ax.set_xlabel('Returns')
-    ax.set_title("Annual Returns")
+    ax.set_title("Annual returns")
     ax.legend(['mean'])
     return ax
 
@@ -315,7 +315,7 @@ def plot_monthly_returns_dist(returns, ax=None, **kwargs):
     ax.legend(['mean'])
     ax.set_ylabel('Number of months')
     ax.set_xlabel('Returns')
-    ax.set_title("Distribution of Monthly Returns")
+    ax.set_title("Distribution of monthly returns")
     return ax
 
 
@@ -375,7 +375,7 @@ def plot_holdings(returns, positions, legend_loc='best', ax=None, **kwargs):
                'Average daily holdings, by month',
                'Average daily holdings, net'],
               loc=legend_loc)
-    ax.set_title('Holdings per Day')
+    ax.set_title('Holdings per day')
     ax.set_ylabel('Amount of holdings per day')
     ax.set_xlabel('')
     return ax
@@ -426,7 +426,7 @@ def plot_drawdown_periods(returns, top=10, ax=None, **kwargs):
                         alpha=.4,
                         color=colors[i])
 
-    ax.set_title('Top %i Drawdown Periods' % top)
+    ax.set_title('Top %i drawdown periods' % top)
     ax.set_ylabel('Cumulative returns')
     ax.legend(['Portfolio'], loc='upper left')
     ax.set_xlabel('')
@@ -465,7 +465,7 @@ def plot_drawdown_underwater(returns, ax=None, **kwargs):
     underwater = -100 * ((running_max - df_cum_rets) / running_max)
     (underwater).plot(ax=ax, kind='area', color='coral', alpha=0.7, **kwargs)
     ax.set_ylabel('Drawdown')
-    ax.set_title('Underwater Plot')
+    ax.set_title('Underwater plot')
     ax.set_xlabel('')
     return ax
 
@@ -617,7 +617,8 @@ def plot_returns(returns,
     if ax is None:
         ax = plt.gca()
 
-    ax.set(xlabel='', ylabel='Returns')
+    ax.set_label('')
+    ax.set_ylabel('Returns')
 
     if live_start_date is not None:
         live_start_date = utils.get_utc_timestamp(live_start_date)
@@ -695,8 +696,9 @@ def plot_rolling_returns(returns,
     if ax is None:
         ax = plt.gca()
 
-    ax.set(xlabel='', ylabel='Cumulative returns',
-           yscale='log' if logy else 'linear')
+    ax.set_xlabel('')
+    ax.set_ylabel('Cumulative returns')
+    ax.set_yscale('log' if logy else 'linear')
 
     if volatility_match and factor_returns is None:
         raise ValueError('volatility_match requires passing of'
@@ -790,7 +792,7 @@ def plot_rolling_beta(returns, factor_returns, legend_loc='best',
     y_axis_formatter = FuncFormatter(utils.two_dec_places)
     ax.yaxis.set_major_formatter(FuncFormatter(y_axis_formatter))
 
-    ax.set_title("Rolling Portfolio Beta to " + str(factor_returns.name))
+    ax.set_title("Rolling portfolio beta to " + str(factor_returns.name))
     ax.set_ylabel('Beta')
     rb_1 = timeseries.rolling_beta(
         returns, factor_returns, rolling_window=APPROX_BDAYS_PER_MONTH * 6)
@@ -896,8 +898,8 @@ def plot_gross_leverage(returns, gross_lev, ax=None, **kwargs):
     ax.axhline(gross_lev.mean(), color='g', linestyle='--', lw=3,
                alpha=1.0)
 
-    ax.set_title('Gross Leverage')
-    ax.set_ylabel('Gross Leverage')
+    ax.set_title('Gross leverage')
+    ax.set_ylabel('Gross leverage')
     ax.set_xlabel('')
     return ax
 
@@ -933,7 +935,7 @@ def plot_exposures(returns, positions_alloc, ax=None, **kwargs):
         kind='line', style=['-g', '-r', '--k'], alpha=1.0,
         ax=ax, **kwargs)
     ax.set_xlim((returns.index[0], returns.index[-1]))
-    ax.set_title("Long/Short Exposure")
+    ax.set_title("Long and short exposure")
     ax.set_ylabel('Exposure')
     ax.set_xlabel('')
     return ax
@@ -1002,7 +1004,7 @@ def show_and_plot_top_positions(returns, positions_alloc,
             ax = plt.gca()
 
         positions_alloc[df_top_abs.index].plot(
-            title='Portfolio Allocation Over Time, Only Top 10 Holdings',
+            title='Portfolio allocation over time, only top 10 holdings',
             alpha=0.4, ax=ax, **kwargs)
 
         # Place legend below plot, shrink plot by 20%
@@ -1054,7 +1056,7 @@ def plot_max_median_position_concentration(positions, ax=None, **kwargs):
 
     ax.legend(loc='center left')
     ax.set_ylabel('Exposure')
-    ax.set_title('Long/Short Max and Median Position Concentration')
+    ax.set_title('Long/Short max and median position concentration')
 
     return ax
 
@@ -1084,7 +1086,7 @@ def plot_sector_allocations(returns, sector_alloc, ax=None, **kwargs):
     if ax is None:
         ax = plt.gcf()
 
-    sector_alloc.plot(title='Sector Allocation Over Time',
+    sector_alloc.plot(title='Sector allocation over time',
                       alpha=0.4, ax=ax, **kwargs)
 
     box = ax.get_position()
@@ -1149,7 +1151,7 @@ def plot_return_quantiles(returns, live_start_date=None, ax=None, **kwargs):
                                            label="Out-of-sample data",
                                            linestyle='')
         ax.legend(handles=[red_dots])
-    ax.set_xticklabels(['daily', 'weekly', 'monthly'])
+    ax.set_xticklabels(['Daily', 'Weekly', 'Monthly'])
     ax.set_title('Return quantiles')
 
     return ax
@@ -1220,7 +1222,7 @@ def plot_turnover(returns, transactions, positions,
     ax.yaxis.set_major_formatter(FuncFormatter(y_axis_formatter))
 
     df_turnover = txn.get_turnover(positions, transactions)
-    df_turnover_by_month = df_turnover.resample("M")
+    df_turnover_by_month = df_turnover.resample("M").mean()
     df_turnover.plot(color='steelblue', alpha=1.0, lw=0.5, ax=ax, **kwargs)
     df_turnover_by_month.plot(
         color='orangered',
@@ -1234,7 +1236,7 @@ def plot_turnover(returns, transactions, positions,
                'Average daily turnover, by month',
                'Average daily turnover, net'],
               loc=legend_loc)
-    ax.set_title('Daily Turnover')
+    ax.set_title('Daily turnover')
     ax.set_xlim((returns.index[0], returns.index[-1]))
     ax.set_ylim((0, 1))
     ax.set_ylabel('Turnover')
@@ -1287,7 +1289,7 @@ def plot_slippage_sweep(returns, transactions, positions,
 
     slippage_sweep.plot(alpha=1.0, lw=0.5, ax=ax)
 
-    ax.set_title('Cumulative Returns Given Additional Per-Dollar Slippage')
+    ax.set_title('Cumulative returns given additional per-dollar slippage')
     ax.set_ylabel('')
 
     ax.legend(loc='center left')
@@ -1335,10 +1337,10 @@ def plot_slippage_sensitivity(returns, transactions, positions,
 
     avg_returns_given_slippage.plot(alpha=1.0, lw=2, ax=ax)
 
-    ax.set(title='Average Annual Returns Given Additional Per-Dollar Slippage',
-           xticks=np.arange(0, 100, 10),
-           ylabel='Average Annual Return',
-           xlabel='Per-Dollar Slippage (bps)')
+    ax.set_title('Average annual returns given additional per-dollar slippage')
+    ax.set_xticks(np.arange(0, 100, 10))
+    ax.set_ylabel('Average annual return')
+    ax.set_xlabel('Per-dollar slippage (bps)')
 
     return ax
 
@@ -1368,9 +1370,9 @@ def plot_capacity_sweep(returns, transactions, market_data,
         ax = plt.gca()
 
     captial_base_sweep.plot(ax=ax)
-    ax.set(xlabel='Capital Base ($mm)',
-           ylabel='Sharpe Ratio',
-           title='Capital Base Performance Sweep')
+    ax.set_xlabel('Capital base ($mm)')
+    ax.set_ylabel('Sharpe ratio')
+    ax.set_title('Capital base performance sweep')
 
     return ax
 
@@ -1403,8 +1405,8 @@ def plot_daily_turnover_hist(transactions, positions,
         ax = plt.gca()
     turnover = txn.get_turnover(positions, transactions, period=None)
     sns.distplot(turnover, ax=ax, **kwargs)
-    ax.set_title('Distribution of Daily Turnover Rates')
-    ax.set_xlabel('Turnover Rate')
+    ax.set_title('Distribution of daily turnover rates')
+    ax.set_xlabel('Turnover rate')
     return ax
 
 
@@ -1439,7 +1441,7 @@ def plot_daily_volume(returns, transactions, ax=None, **kwargs):
     daily_txn.txn_shares.plot(alpha=1.0, lw=0.5, ax=ax, **kwargs)
     ax.axhline(daily_txn.txn_shares.mean(), color='steelblue',
                linestyle='--', lw=3, alpha=1.0)
-    ax.set_title('Daily Trading Volume')
+    ax.set_title('Daily trading volume')
     ax.set_xlim((returns.index[0], returns.index[-1]))
     ax.set_ylabel('Amount of shares traded')
     ax.set_xlabel('')
@@ -1494,14 +1496,14 @@ def plot_txn_time_hist(transactions, bin_minutes=5, tz='America/New_York',
     ax.set_xlim(570, 960)
     ax.set_xticks(txn_time.index[::int(30/bin_minutes)])
     ax.set_xticklabels(txn_time.time_str[::int(30/bin_minutes)])
-    ax.set_title('Transaction Time Distribution')
+    ax.set_title('Transaction time distribution')
     ax.set_ylabel('Proportion')
     ax.set_xlabel('')
     return ax
 
 
 def plot_daily_returns_similarity(returns_backtest, returns_live,
-                                  title='', ax=None, **kwargs):
+                                  ax=None, **kwargs):
     """
     Plots overlapping distributions of in-sample (backtest) returns
     and out-of-sample (live trading) returns.
@@ -1534,7 +1536,6 @@ def plot_daily_returns_similarity(returns_backtest, returns_live,
     sns.kdeplot(utils.standardize_data(returns_live),
                 bw='scott', shade=True, label='out-of-sample',
                 color='red', ax=ax, **kwargs)
-    ax.set_title(title)
 
     return ax
 
@@ -1558,7 +1559,7 @@ def show_worst_drawdown_periods(returns, top=5):
     drawdown_df = timeseries.gen_drawdown_table(returns, top=top)
     utils.print_table(drawdown_df.sort_values('net drawdown in %',
                                               ascending=False),
-                      name='Worst Drawdown Periods', fmt='{0:.2f}')
+                      name='Worst drawdown periods', fmt='{0:.2f}')
 
 
 def plot_monthly_returns_timeseries(returns, ax=None, **kwargs):
@@ -1726,8 +1727,10 @@ def plot_prob_profit_trade(round_trips, ax=None):
     ax.axvline(lower_perc, color='0.5')
     ax.axvline(upper_perc, color='0.5')
 
-    ax.set(xlabel='Probability making a profitable decision', ylabel='Belief',
-           xlim=(lower_plot, upper_plot), ylim=(0, y.max() + 1.))
+    ax.set_xlabel('Probability of making a profitable decision')
+    ax.set_ylabel('Belief')
+    ax.set_xlim(lower_plot, upper_plot)
+    ax.set_ylim((0, y.max() + 1.))
 
     return ax
 

--- a/pyfolio/pos.py
+++ b/pyfolio/pos.py
@@ -33,6 +33,7 @@ def get_percent_alloc(values):
     allocations : pd.DataFrame
         Positions and their allocations.
     """
+
     return values.divide(
         values.sum(axis='columns'),
         axis='rows'
@@ -114,6 +115,7 @@ def get_max_median_position_concentration(positions):
         Columns are max long, max short, median long, and median short
         position concentrations. Rows are timeperiods.
     """
+
     expos = get_percent_alloc(positions)
     expos = expos.drop('cash', axis=1)
 
@@ -130,7 +132,8 @@ def get_max_median_position_concentration(positions):
 
 
 def extract_pos(positions, cash):
-    """Extract position values from backtest object as returned by
+    """
+    Extract position values from backtest object as returned by
     get_backtest() on the Quantopian research platform.
 
     Parameters
@@ -148,6 +151,7 @@ def extract_pos(positions, cash):
         Daily net position values.
          - See full explanation in tears.create_full_tear_sheet.
     """
+
     positions = positions.copy()
     positions['values'] = positions.amount * positions.last_sale_price
     cash.name = 'cash'
@@ -190,6 +194,7 @@ def get_sector_exposures(positions, symbol_sector_map):
             2004-01-12    -4132.240       142.630             3989.6100
             2004-01-13    -199.640        -100.980            100.0000
     """
+
     cash = positions['cash']
     positions = positions.drop('cash', axis=1)
 

--- a/pyfolio/round_trips.py
+++ b/pyfolio/round_trips.py
@@ -257,13 +257,13 @@ def extract_round_trips(transactions,
         pv = pd.DataFrame(portfolio_value,
                           columns=['portfolio_value'])\
             .assign(date=portfolio_value.index)
+
         roundtrips['date'] = roundtrips.close_dt.apply(lambda x:
                                                        x.replace(hour=0,
                                                                  minute=0,
                                                                  second=0))
-
-        tmp = roundtrips.assign(date=roundtrips.close_dt)\
-                        .join(pv, on='date', lsuffix='_')
+        
+        tmp = roundtrips.join(pv, on='date', lsuffix='_')
 
         roundtrips['returns'] = tmp.pnl / tmp.portfolio_value
         roundtrips = roundtrips.drop('date', axis='columns')

--- a/pyfolio/round_trips.py
+++ b/pyfolio/round_trips.py
@@ -262,7 +262,7 @@ def extract_round_trips(transactions,
                                                        x.replace(hour=0,
                                                                  minute=0,
                                                                  second=0))
-        
+
         tmp = roundtrips.join(pv, on='date', lsuffix='_')
 
         roundtrips['returns'] = tmp.pnl / tmp.portfolio_value

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -616,7 +616,7 @@ def create_round_trip_tear_sheet(returns, positions, transactions,
     ax_pnl_per_round_trip_dollars = plt.subplot(gs[2, 0])
     ax_pnl_per_round_trip_pct = plt.subplot(gs[2, 1])
 
-    plotting.plot_round_trip_life_times(trades, ax=ax_trade_lifetimes)
+    plotting.plot_round_trip_lifetimes(trades, ax=ax_trade_lifetimes)
 
     plotting.plot_prob_profit_trade(trades, ax=ax_prob_profit_trade)
 

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -313,7 +313,7 @@ def create_returns_tear_sheet(returns, live_start_date=None,
         cone_std=cone_std,
         ax=ax_rolling_returns)
     ax_rolling_returns.set_title(
-        'Cumulative Returns')
+        'Cumulative returns')
 
     plotting.plot_rolling_returns(
         returns,
@@ -324,7 +324,7 @@ def create_returns_tear_sheet(returns, live_start_date=None,
         legend_loc=None,
         ax=ax_rolling_returns_vol_match)
     ax_rolling_returns_vol_match.set_title(
-        'Cumulative returns volatility matched to benchmark.')
+        'Cumulative returns volatility matched to benchmark')
 
     plotting.plot_rolling_returns(
         returns,
@@ -334,7 +334,7 @@ def create_returns_tear_sheet(returns, live_start_date=None,
         cone_std=cone_std,
         ax=ax_rolling_returns_log)
     ax_rolling_returns_log.set_title(
-        'Cumulative Returns on logarithmic scale')
+        'Cumulative returns on logarithmic scale')
 
     plotting.plot_returns(
         returns,

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -506,6 +506,7 @@ def create_txn_tear_sheet(returns, positions, transactions,
     return_fig : boolean, optional
         If True, returns the figure that was plotted on.
     """
+
     vertical_sections = 6 if unadjusted_returns is not None else 4
 
     fig = plt.figure(figsize=(14, vertical_sections * 6))
@@ -665,6 +666,7 @@ def create_interesting_times_tear_sheet(
     set_context : boolean, optional
         If True, set default plotting style context.
     """
+
     rets_interesting = timeseries.extract_interesting_date_ranges(returns)
 
     if len(rets_interesting) == 0:
@@ -839,6 +841,7 @@ def create_bayesian_tear_sheet(returns, benchmark_rets=None,
     stoch_vol : boolean, optional
         If True, run and plot the stochastic volatility model
     """
+
     if not have_bayesian:
         raise NotImplementedError(
             "Bayesian tear sheet requirements not found.\n"

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -506,13 +506,14 @@ def create_txn_tear_sheet(returns, positions, transactions,
     return_fig : boolean, optional
         If True, returns the figure that was plotted on.
     """
-    vertical_sections = 5 if unadjusted_returns is not None else 3
+    vertical_sections = 6 if unadjusted_returns is not None else 4
 
     fig = plt.figure(figsize=(14, vertical_sections * 6))
     gs = gridspec.GridSpec(vertical_sections, 3, wspace=0.5, hspace=0.5)
     ax_turnover = plt.subplot(gs[0, :])
     ax_daily_volume = plt.subplot(gs[1, :], sharex=ax_turnover)
     ax_turnover_hist = plt.subplot(gs[2, :])
+    ax_txn_timings = plt.subplot(gs[3, :])
 
     plotting.plot_turnover(
         returns,
@@ -528,14 +529,16 @@ def create_txn_tear_sheet(returns, positions, transactions,
     except ValueError:
         warnings.warn('Unable to generate turnover plot.', UserWarning)
 
+    plotting.plot_txn_time_hist(transactions, ax=ax_txn_timings)
+
     if unadjusted_returns is not None:
-        ax_slippage_sweep = plt.subplot(gs[3, :])
+        ax_slippage_sweep = plt.subplot(gs[4, :])
         plotting.plot_slippage_sweep(unadjusted_returns,
                                      transactions,
                                      positions,
                                      ax=ax_slippage_sweep
                                      )
-        ax_slippage_sensitivity = plt.subplot(gs[4, :])
+        ax_slippage_sensitivity = plt.subplot(gs[5, :])
         plotting.plot_slippage_sensitivity(unadjusted_returns,
                                            transactions,
                                            positions,

--- a/pyfolio/txn.py
+++ b/pyfolio/txn.py
@@ -31,7 +31,7 @@ def map_transaction(txn):
     dict
         Mapped transaction.
     """
-    # sid can either be just a single value or a SID descriptor
+
     if isinstance(txn['sid'], dict):
         sid = txn['sid']['sid']
         symbol = txn['sid']['symbol']
@@ -81,7 +81,8 @@ def make_transaction_frame(transactions):
 
 
 def get_txn_vol(transactions):
-    """Extract daily transaction data from set of transaction objects.
+    """
+    Extract daily transaction data from set of transaction objects.
 
     Parameters
     ----------
@@ -96,6 +97,7 @@ def get_txn_vol(transactions):
         Daily transaction volume and number of shares.
          - See full explanation in tears.create_full_tear_sheet.
     """
+
     txn_norm = transactions.copy()
     txn_norm.index = txn_norm.index.normalize()
     amounts = txn_norm.amount.abs()
@@ -109,7 +111,8 @@ def get_txn_vol(transactions):
 
 
 def adjust_returns_for_slippage(returns, turnover, slippage_bps):
-    """Apply a slippage penalty for every dollar traded.
+    """
+    Apply a slippage penalty for every dollar traded.
 
     Parameters
     ----------
@@ -127,6 +130,7 @@ def adjust_returns_for_slippage(returns, turnover, slippage_bps):
     pd.Series
         Time series of daily returns, adjusted for slippage.
     """
+
     slippage = 0.0001 * slippage_bps
     # Only include returns in the period where the algo traded.
     trim_returns = returns.loc[turnover.index]
@@ -162,6 +166,7 @@ def get_turnover(positions, transactions, period=None, average=True):
     turnover_rate : pd.Series
         timeseries of portfolio turnover rates.
     """
+
     txn_vol = get_txn_vol(transactions)
     traded_value = txn_vol.txn_volume
     portfolio_value = positions.sum(axis=1)

--- a/pyfolio/txn.py
+++ b/pyfolio/txn.py
@@ -96,9 +96,10 @@ def get_txn_vol(transactions):
         Daily transaction volume and number of shares.
          - See full explanation in tears.create_full_tear_sheet.
     """
-    transactions.index = transactions.index.normalize()
-    amounts = transactions.amount.abs()
-    prices = transactions.price
+    txn_norm = transactions.copy()
+    txn_norm.index = txn_norm.index.normalize()
+    amounts = txn_norm.amount.abs()
+    prices = txn_norm.price
     values = amounts * prices
     daily_amounts = amounts.groupby(amounts.index).sum()
     daily_values = values.groupby(values.index).sum()

--- a/pyfolio/utils.py
+++ b/pyfolio/utils.py
@@ -70,6 +70,7 @@ def ensure_directory(path):
     """
     Ensure that a directory named "path" exists.
     """
+
     try:
         makedirs(path)
     except OSError as exc:
@@ -103,7 +104,7 @@ def percentage(x, pos):
 
 def get_utc_timestamp(dt):
     """
-    returns the Timestamp/DatetimeIndex
+    Returns the Timestamp/DatetimeIndex
     with either localized or converted to UTC.
 
     Parameters
@@ -116,6 +117,7 @@ def get_utc_timestamp(dt):
     same type as input
         date(s) converted to UTC
     """
+
     dt = pd.to_datetime(dt)
     try:
         dt = dt.tz_localize('UTC')
@@ -132,7 +134,8 @@ def _1_bday_ago():
 
 
 def get_returns_cached(filepath, update_func, latest_dt, **kwargs):
-    """Get returns from a cached file if the cache is recent enough,
+    """
+    Get returns from a cached file if the cache is recent enough,
     otherwise, try to retrieve via a provided update function and
     update the cache file.
 
@@ -152,6 +155,7 @@ def get_returns_cached(filepath, update_func, latest_dt, **kwargs):
     pandas.DataFrame
         DataFrame containing returns
     """
+
     update_cache = False
 
     try:
@@ -193,7 +197,8 @@ def get_returns_cached(filepath, update_func, latest_dt, **kwargs):
 
 
 def get_symbol_from_yahoo(symbol, start=None, end=None):
-    """Wrapper for pandas.io.data.get_data_yahoo().
+    """
+    Wrapper for pandas.io.data.get_data_yahoo().
     Retrieves prices for symbol from yahoo and computes returns
     based on adjusted closing prices.
 
@@ -211,6 +216,7 @@ def get_symbol_from_yahoo(symbol, start=None, end=None):
     pandas.DataFrame
         Returns of symbol in requested period.
     """
+
     px = web.get_data_yahoo(symbol, start=start, end=end)
     rets = px[['Adj Close']].pct_change().dropna()
     rets.index = rets.index.tz_localize("UTC")
@@ -240,6 +246,7 @@ def default_returns_func(symbol, start=None, end=None):
         Daily returns for the symbol.
          - See full explanation in tears.create_full_tear_sheet (returns).
     """
+
     if start is None:
         start = '1/1/1970'
     if end is None:
@@ -264,7 +271,8 @@ def default_returns_func(symbol, start=None, end=None):
 
 
 def vectorize(func):
-    """Decorator so that functions can be written to work on Series but
+    """
+    Decorator so that functions can be written to work on Series but
     may still be called with DataFrames.
     """
 
@@ -278,13 +286,15 @@ def vectorize(func):
 
 
 def get_fama_french():
-    """Retrieve Fama-French factors via pandas-datareader
+    """
+    Retrieve Fama-French factors via pandas-datareader
 
     Returns
     -------
     pandas.DataFrame
         Percent change of Fama-French factors
     """
+
     start = '1/1/1970'
     research_factors = web.DataReader('F-F_Research_Data_Factors_daily',
                                       'famafrench', start=start)[0]
@@ -299,7 +309,7 @@ def get_fama_french():
 
 def load_portfolio_risk_factors(filepath_prefix=None, start=None, end=None):
     """
-    Loads risk factors Mkt-Rf, SMB, HML, Rf, and UMD.
+    Load risk factors Mkt-Rf, SMB, HML, Rf, and UMD.
 
     Data is stored in HDF5 file. If the data is more than 2
     days old, redownload from Dartmouth.
@@ -309,6 +319,7 @@ def load_portfolio_risk_factors(filepath_prefix=None, start=None, end=None):
     five_factors : pd.DataFrame
         Risk factors timeseries.
     """
+
     if start is None:
         start = '1/1/1970'
     if end is None:
@@ -328,7 +339,8 @@ def load_portfolio_risk_factors(filepath_prefix=None, start=None, end=None):
 
 
 def get_treasury_yield(start=None, end=None, period='3MO'):
-    """Load treasury yields from FRED.
+    """
+    Load treasury yields from FRED.
 
     Parameters
     ----------
@@ -346,6 +358,7 @@ def get_treasury_yield(start=None, end=None, period='3MO'):
     pd.Series
         Annual treasury yield for every day.
     """
+
     if start is None:
         start = '1/1/1970'
     if end is None:
@@ -360,7 +373,8 @@ def get_treasury_yield(start=None, end=None, period='3MO'):
 
 
 def extract_rets_pos_txn_from_zipline(backtest):
-    """Extract returns, positions, transactions and leverage from the
+    """
+    Extract returns, positions, transactions and leverage from the
     backtest data structure returned by zipline.TradingAlgorithm.run().
 
     The returned data structures are in a format compatible with the
@@ -395,7 +409,6 @@ def extract_rets_pos_txn_from_zipline(backtest):
     >>>     pyfolio.utils.extract_rets_pos_txn_from_zipline(backtest)
     >>> pyfolio.tears.create_full_tear_sheet(returns,
     >>>     positions, transactions, gross_lev=gross_lev)
-
     """
 
     backtest.index = backtest.index.normalize()
@@ -445,6 +458,7 @@ def register_return_func(func):
     -------
     None
     """
+
     SETTINGS['returns_func'] = func
 
 
@@ -470,6 +484,7 @@ def get_symbol_rets(symbol, start=None, end=None):
     pandas.Series
         Returned by the current 'returns_func'
     """
+
     return SETTINGS['returns_func'](symbol,
                                     start=start,
                                     end=end)
@@ -492,8 +507,8 @@ def print_table(table, name=None, fmt=None):
         Formatter to use for displaying table elements.
         E.g. '{0:.2f}%' for displaying 100 as '100.00%'.
         Restores original setting after displaying.
-
     """
+
     if isinstance(table, pd.Series):
         table = pd.DataFrame(table)
 
@@ -524,4 +539,5 @@ def standardize_data(x):
     np.array
         Standardized array.
     """
+
     return (x - np.mean(x)) / np.std(x)


### PR DESCRIPTION
- There's a new transaction time plot that shows transaction time over the day. The default timezone is EST.
- Doc string spacing is now correct.
- Title and axis capitalization standardized.
- Bug fix for the returns generation for round trips.
- Round trip lifetimes plot has been modified to now only show a maximum of 12 assets. If the strategy has traded more than 12 assets, the top 12 assets are shown, sorted by their hold duration.

Closes #343 & #344.