### PR TITLE
BUG: Don't use is to check string equality.

### DIFF
--- a/pyfolio/utils.py
+++ b/pyfolio/utils.py
@@ -617,7 +617,7 @@ def check_intraday(estimate, returns, positions, transactions):
         Daily net position values, adjusted for intraday movement.
     """
 
-    if estimate is 'infer':
+    if estimate == 'infer':
         if positions is not None and transactions is not None:
             if detect_intraday(positions, transactions):
                 warnings.warn('Detected intraday strategy; inferring positi' +


### PR DESCRIPTION
`is` means "is the same object in memory", which is almost certainly not what you want here. It will happen to work in some cases because string literals are memoized by the CPython runtime, but that's not guaranteed behavior, and this will fail if it ever encounters a dynamically constructed string:

```
In [4]: "foo" is "foo"
Out[4]: True

In [5]: "".join(['f', 'o', 'o'])
Out[5]: 'foo'

In [6]: "".join(['f', 'o', 'o']) is "foo"
Out[6]: False
```