### PR TITLE
Update perf_stats table, update holdings plots, other various fixes

### DIFF
--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -680,7 +680,7 @@ def show_perf_stats(returns, factor_returns, positions=None,
     for column in perf_stats.columns:
         for stat, value in perf_stats[column].iteritems():
             if stat in STAT_FUNCS_PCT:
-                perf_stats.loc[stat, column] = str(np.round(value *100,
+                perf_stats.loc[stat, column] = str(np.round(value * 100,
                                                             1)) + '%'
 
     utils.print_table(perf_stats, fmt='{0:.2f}')

--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -578,6 +578,7 @@ STAT_FUNCS_PCT = [
     'Daily turnover'
 ]
 
+
 def show_perf_stats(returns, factor_returns, positions=None,
                     transactions=None, live_start_date=None,
                     bootstrap=False):
@@ -670,7 +671,8 @@ def show_perf_stats(returns, factor_returns, positions=None,
     for column in perf_stats.columns:
         for stat, value in perf_stats[column].iteritems():
             if stat in STAT_FUNCS_PCT:
-                perf_stats.loc[stat, column] = str(np.round(value * 100, 1)) + '%'
+                perf_stats.loc[stat, column] = str(np.round(value *100,
+                                                            1)) + '%'
 
     utils.print_table(perf_stats, fmt='{0:.2f}')
 

--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -569,6 +569,15 @@ def plot_perf_stats(returns, factor_returns, ax=None):
     return ax
 
 
+STAT_FUNCS_PCT = [
+    'Annual return',
+    'Cumulative returns',
+    'Annual volatility',
+    'Max drawdown',
+    'Daily value at risk',
+    'Daily turnover'
+]
+
 def show_perf_stats(returns, factor_returns, positions=None,
                     transactions=None, live_start_date=None,
                     bootstrap=False):
@@ -657,6 +666,11 @@ def show_perf_stats(returns, factor_returns, positions=None,
         print('Backtest months: ' +
               str(int(len(returns) / APPROX_BDAYS_PER_MONTH)))
         perf_stats = pd.DataFrame(perf_stats_all, columns=['Backtest'])
+
+    for column in perf_stats.columns:
+        for stat, value in perf_stats[column].iteritems():
+            if stat in STAT_FUNCS_PCT:
+                perf_stats.loc[stat, column] = str(np.round(value * 100, 1)) + '%'
 
     utils.print_table(perf_stats, fmt='{0:.2f}')
 

--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -371,7 +371,7 @@ def plot_holdings(returns, positions, legend_loc='lower left',
     ax.legend(['Holdings',
                'Average holdings, by month',
                'Average holdings, total'],
-              loc=legend_loc, frameon=True, prop={'size':12})
+              loc=legend_loc, frameon=True, prop={'size': 12})
     ax.set_title('Total holdings')
     ax.set_ylabel('Holdings')
     ax.set_xlabel('')
@@ -438,7 +438,7 @@ def plot_long_short_holdings(returns, positions,
                (df_shorts.max(), df_shorts.min()),
                'Average long holdings',
                'Average short holdings'],
-              loc=legend_loc, frameon=True, prop={'size':12})
+              loc=legend_loc, frameon=True, prop={'size': 12})
     ax.set_title('Long and short holdings')
     ax.set_ylabel('Holdings')
     ax.set_xlabel('')

--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -562,7 +562,7 @@ def plot_perf_stats(returns, factor_returns, ax=None):
     bootstrap_values = timeseries.perf_stats_bootstrap(returns,
                                                        factor_returns,
                                                        return_stats=False)
-    bootstrap_values = bootstrap_values.drop('kurtosis', axis='columns')
+    bootstrap_values = bootstrap_values.drop('Kurtosis', axis='columns')
 
     sns.boxplot(data=bootstrap_values, orient='h', ax=ax)
 

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -445,7 +445,7 @@ def create_position_tear_sheet(returns, positions,
     ax_top_positions = plt.subplot(gs[1, :], sharex=ax_exposures)
     ax_max_median_pos = plt.subplot(gs[2, :], sharex=ax_exposures)
     ax_holdings = plt.subplot(gs[3, :], sharex=ax_exposures)
-    ax_long_short_holdings = plt.subplot(gs[4, :], sharex=ax_exposures)
+    ax_long_short_holdings = plt.subplot(gs[4, :])
     ax_gross_leverage = plt.subplot(gs[5, :], sharex=ax_exposures)
 
     positions_alloc = pos.get_percent_alloc(positions)

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -128,6 +128,9 @@ def create_full_tear_sheet(returns,
         If True, causes the generation of a Bayesian tear sheet.
     round_trips: boolean, optional
         If True, causes the generation of a round trip tear sheet.
+    sector_mappings : dict or pd.Series, optional
+        Security identifier to sector mapping.
+        Security ids as keys, sectors as values.
     estimate_intraday: boolean or str, optional
         Instead of using the end-of-day positions, use the point in the day
         where we have the most $ invested. This will adjust positions to
@@ -163,6 +166,7 @@ def create_full_tear_sheet(returns,
     create_returns_tear_sheet(
         returns,
         positions=positions,
+        transactions=transactions,
         live_start_date=live_start_date,
         cone_std=cone_std,
         benchmark_rets=benchmark_rets,
@@ -208,6 +212,7 @@ def create_full_tear_sheet(returns,
 
 @plotting_context
 def create_returns_tear_sheet(returns, positions=None,
+                              transactions=None,
                               live_start_date=None,
                               cone_std=(1.0, 1.5, 2.0),
                               benchmark_rets=None,
@@ -254,19 +259,19 @@ def create_returns_tear_sheet(returns, positions=None,
 
     if benchmark_rets is None:
         benchmark_rets = utils.get_symbol_rets('SPY')
-        # If the strategy's history is longer than the benchmark's, limit
-        # strategy
-        if returns.index[0] < benchmark_rets.index[0]:
-            returns = returns[returns.index > benchmark_rets.index[0]]
+
+    returns = returns[returns.index > benchmark_rets.index[0]]
 
     print("Entire data start date: %s" % returns.index[0].strftime('%Y-%m-%d'))
     print("Entire data end date: %s" % returns.index[-1].strftime('%Y-%m-%d'))
-    print('\n')
 
     plotting.show_perf_stats(returns, benchmark_rets,
                              positions=positions,
+                             transactions=transactions,
                              bootstrap=bootstrap,
                              live_start_date=live_start_date)
+
+    plotting.show_worst_drawdown_periods(returns)
 
     # If the strategy's history is longer than the benchmark's, limit strategy
     if returns.index[0] < benchmark_rets.index[0]:
@@ -365,11 +370,6 @@ def create_returns_tear_sheet(returns, positions=None,
 
     plotting.plot_drawdown_underwater(
         returns=returns, ax=ax_underwater)
-
-    plotting.show_worst_drawdown_periods(returns)
-
-    print('\n')
-    plotting.show_return_range(returns)
 
     plotting.plot_monthly_returns_heatmap(returns, ax=ax_monthly_heatmap)
     plotting.plot_annual_returns(returns, ax=ax_annual_returns)
@@ -629,7 +629,6 @@ def create_round_trip_tear_sheet(returns, positions, transactions,
 
     fig = plt.figure(figsize=(14, 3 * 6))
 
-    fig = plt.figure(figsize=(14, 3 * 6))
     gs = gridspec.GridSpec(3, 2, wspace=0.5, hspace=0.5)
 
     ax_trade_lifetimes = plt.subplot(gs[0, :])

--- a/pyfolio/tests/test_timeseries.py
+++ b/pyfolio/tests/test_timeseries.py
@@ -33,7 +33,7 @@ class TestDrawdown(TestCase):
     def test_get_max_drawdown_begins_first_day(self, px):
         rets = px.pct_change()
         drawdowns = timeseries.gen_drawdown_table(rets, top=1)
-        self.assertEqual(drawdowns.loc[0, 'net drawdown in %'], 25)
+        self.assertEqual(drawdowns.loc[0, 'Net drawdown in %'], 25)
 
     drawdown_list = np.array(
         [100, 110, 120, 150, 180, 200, 100, 120,

--- a/pyfolio/tests/test_timeseries.py
+++ b/pyfolio/tests/test_timeseries.py
@@ -68,22 +68,22 @@ class TestDrawdown(TestCase):
 
         drawdowns = timeseries.gen_drawdown_table(rets, top=2)
 
-        self.assertEqual(np.round(drawdowns.loc[0, 'net drawdown in %']),
+        self.assertEqual(np.round(drawdowns.loc[0, 'Net drawdown in %']),
                          first_net_drawdown)
-        self.assertEqual(drawdowns.loc[0, 'peak date'],
+        self.assertEqual(drawdowns.loc[0, 'Peak date'],
                          first_expected_peak)
-        self.assertEqual(drawdowns.loc[0, 'valley date'],
+        self.assertEqual(drawdowns.loc[0, 'Valley date'],
                          first_expected_valley)
-        self.assertEqual(drawdowns.loc[0, 'recovery date'],
+        self.assertEqual(drawdowns.loc[0, 'Recovery date'],
                          first_expected_recovery)
 
-        self.assertEqual(np.round(drawdowns.loc[1, 'net drawdown in %']),
+        self.assertEqual(np.round(drawdowns.loc[1, 'Net drawdown in %']),
                          second_net_drawdown)
-        self.assertEqual(drawdowns.loc[1, 'peak date'],
+        self.assertEqual(drawdowns.loc[1, 'Peak date'],
                          second_expected_peak)
-        self.assertEqual(drawdowns.loc[1, 'valley date'],
+        self.assertEqual(drawdowns.loc[1, 'Valley date'],
                          second_expected_valley)
-        self.assertTrue(pd.isnull(drawdowns.loc[1, 'recovery date']))
+        self.assertTrue(pd.isnull(drawdowns.loc[1, 'Recovery date']))
 
     px_list_1 = np.array(
         [100, 120, 100, 80, 70, 110, 180, 150]) / 100.  # Simple
@@ -148,25 +148,25 @@ class TestDrawdown(TestCase):
             pd.isnull(
                 drawdowns.loc[
                     0,
-                    'peak date'])) if expected_peak is None \
-            else self.assertEqual(drawdowns.loc[0, 'peak date'],
+                    'Peak date'])) if expected_peak is None \
+            else self.assertEqual(drawdowns.loc[0, 'Peak date'],
                                   expected_peak)
         self.assertTrue(
             pd.isnull(
-                drawdowns.loc[0, 'valley date'])) \
+                drawdowns.loc[0, 'Valley date'])) \
             if expected_valley is None else self.assertEqual(
-                drawdowns.loc[0, 'valley date'],
+                drawdowns.loc[0, 'Valley date'],
                 expected_valley)
         self.assertTrue(
             pd.isnull(
-                drawdowns.loc[0, 'recovery date'])) \
+                drawdowns.loc[0, 'Recovery date'])) \
             if expected_recovery is None else self.assertEqual(
-                drawdowns.loc[0, 'recovery date'],
+                drawdowns.loc[0, 'Recovery date'],
                 expected_recovery)
         self.assertTrue(
-            pd.isnull(drawdowns.loc[0, 'duration'])) \
+            pd.isnull(drawdowns.loc[0, 'Duration'])) \
             if expected_duration is None else self.assertEqual(
-                drawdowns.loc[0, 'duration'], expected_duration)
+                drawdowns.loc[0, 'Duration'], expected_duration)
 
     def test_drawdown_overlaps(self):
         # Add test to show that drawdowns don't overlap
@@ -177,11 +177,11 @@ class TestDrawdown(TestCase):
                                    end='2004-12-31')
         spy_drawdowns = timeseries.gen_drawdown_table(
             spy_rets,
-            top=20).sort_values(by='peak date')
+            top=20).sort_values(by='Peak date')
         # Compare the recovery date of each drawdown with the peak of the next
         # Last pair might contain a NaT if drawdown didn't finish, so ignore it
-        pairs = list(zip(spy_drawdowns['recovery date'],
-                         spy_drawdowns['peak date'].shift(-1)))[:-1]
+        pairs = list(zip(spy_drawdowns['Recovery date'],
+                         spy_drawdowns['Peak date'].shift(-1)))[:-1]
         for recovery, peak in pairs:
             self.assertLessEqual(recovery, peak)
 

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -746,7 +746,7 @@ def perf_stats(returns, factor_returns=None, positions=None,
         for stat_func in FACTOR_STAT_FUNCS:
             res = stat_func(returns, factor_returns)
             stats[STAT_FUNC_NAMES[stat_func.__name__]] = res
-    
+
     for stat, value in stats.iteritems():
         if stat in STAT_FUNCS_PCT:
             stats[stat] = str(np.round(value * 100, 1)) + '%'

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -696,15 +696,6 @@ STAT_FUNC_NAMES = {
     'beta': 'Beta',
 }
 
-STAT_FUNCS_PCT = [
-    'Annual return',
-    'Cumulative returns',
-    'Annual volatility',
-    'Max drawdown',
-    'Daily value at risk'
-]
-
-
 def perf_stats(returns, factor_returns=None, positions=None,
                transactions=None):
     """
@@ -746,10 +737,6 @@ def perf_stats(returns, factor_returns=None, positions=None,
         for stat_func in FACTOR_STAT_FUNCS:
             res = stat_func(returns, factor_returns)
             stats[STAT_FUNC_NAMES[stat_func.__name__]] = res
-
-    for stat, value in stats.iteritems():
-        if stat in STAT_FUNCS_PCT:
-            stats[stat] = str(np.round(value * 100, 1)) + '%'
 
     return stats
 

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -25,6 +25,7 @@ import scipy.stats as stats
 from . import utils
 from .utils import APPROX_BDAYS_PER_MONTH, APPROX_BDAYS_PER_YEAR
 from .utils import DAILY
+from .txn import get_turnover
 from .interesting_periods import PERIODS
 from .deprecate import deprecated
 
@@ -460,29 +461,6 @@ def common_sense_ratio(returns):
         (1 + empyrical.annual_return(returns))
 
 
-SIMPLE_STAT_FUNCS = [
-    annual_return,
-    empyrical.cum_returns_final,
-    annual_volatility,
-    sharpe_ratio,
-    calmar_ratio,
-    stability_of_timeseries,
-    max_drawdown,
-    omega_ratio,
-    sortino_ratio,
-    stats.skew,
-    stats.kurtosis,
-    tail_ratio,
-    common_sense_ratio
-]
-
-FACTOR_STAT_FUNCS = [
-    information_ratio,
-    alpha,
-    beta,
-]
-
-
 def normalize(returns, starting_value=1):
     """
     Normalizes a returns timeseries based on the first value.
@@ -652,7 +630,83 @@ def gross_lev(positions):
     return exposure / positions.sum(axis=1)
 
 
-def perf_stats(returns, factor_returns=None, positions=None):
+def value_at_risk(returns, period=None, sigma=2.0):
+    """
+    Get value at risk (VaR).
+
+    Parameters
+    ----------
+    returns : pd.Series
+        Daily returns of the strategy, noncumulative.
+         - See full explanation in tears.create_full_tear_sheet.
+    period : str, optional
+        Period over which to calculate VaR. Set to 'weekly',
+        'monthly', or 'yearly', otherwise defaults to period of
+        returns (typically daily).
+    sigma : float, optional
+        Standard deviations of VaR, default 2.
+    """
+    if period is not None:
+        returns_agg = empyrical.aggregate_returns(returns, period)
+    else:
+        returns_agg = returns.copy()
+
+    value_at_risk = returns_agg.mean() - sigma * returns_agg.std()
+    return value_at_risk
+
+
+SIMPLE_STAT_FUNCS = [
+    annual_return,
+    empyrical.cum_returns_final,
+    annual_volatility,
+    sharpe_ratio,
+    calmar_ratio,
+    stability_of_timeseries,
+    max_drawdown,
+    omega_ratio,
+    sortino_ratio,
+    stats.skew,
+    stats.kurtosis,
+    tail_ratio,
+    common_sense_ratio,
+    value_at_risk
+]
+
+FACTOR_STAT_FUNCS = [
+    alpha,
+    beta,
+]
+
+STAT_FUNC_NAMES = {
+    'annual_return': 'Annual return',
+    'cum_returns_final': 'Cumulative returns',
+    'annual_volatility': 'Annual volatility',
+    'sharpe_ratio': 'Sharpe ratio',
+    'calmar_ratio': 'Calmar ratio',
+    'stability_of_timeseries': 'Stability',
+    'max_drawdown': 'Max drawdown',
+    'omega_ratio': 'Omega ratio',
+    'sortino_ratio': 'Sortino ratio',
+    'skew': 'Skew',
+    'kurtosis': 'Kurtosis',
+    'tail_ratio': 'Tail ratio',
+    'common_sense_ratio': 'Common sense ratio',
+    'value_at_risk': 'Daily value at risk',
+    'alpha': 'Alpha',
+    'beta': 'Beta',
+}
+
+STAT_FUNCS_PCT = [
+    'Annual return',
+    'Cumulative returns',
+    'Annual volatility',
+    'Max drawdown',
+    'Daily value at risk'
+]
+
+
+def perf_stats(returns, factor_returns=None, positions=None,
+               transactions=None):
     """
     Calculates various performance metrics of a strategy, for use in
     plotting.show_perf_stats.
@@ -669,6 +723,9 @@ def perf_stats(returns, factor_returns=None, positions=None):
     positions : pd.DataFrame
         Daily net position values.
          - See full explanation in tears.create_full_tear_sheet.
+    transactions : pd.DataFrame
+        Prices and amounts of executed trades. One row per trade.
+        - See full explanation in tears.create_full_tear_sheet
 
     Returns
     -------
@@ -678,20 +735,27 @@ def perf_stats(returns, factor_returns=None, positions=None):
 
     stats = pd.Series()
     for stat_func in SIMPLE_STAT_FUNCS:
-        stats[stat_func.__name__] = stat_func(returns)
+        stats[STAT_FUNC_NAMES[stat_func.__name__]] = stat_func(returns)
 
     if positions is not None:
-        stats['gross_leverage'] = gross_lev(positions).mean()
+        stats['Gross leverage'] = gross_lev(positions).mean()
+        if transactions is not None:
+            stats['Daily turnover'] = get_turnover(positions, transactions,
+                                                   period='1D').mean()
     if factor_returns is not None:
         for stat_func in FACTOR_STAT_FUNCS:
-            stats[stat_func.__name__] = stat_func(returns,
-                                                  factor_returns)
+            res = stat_func(returns, factor_returns)
+            stats[STAT_FUNC_NAMES[stat_func.__name__]] = res
+    
+    for stat, value in stats.iteritems():
+        if stat in STAT_FUNCS_PCT:
+            stats[stat] = str(np.round(value * 100, 1)) + '%'
 
     return stats
 
 
-def perf_stats_bootstrap(returns, factor_returns=None, positions=None,
-                         return_stats=True):
+def perf_stats_bootstrap(returns, factor_returns=None, return_stats=True,
+                         **kwargs):
     """Calculates various bootstrapped performance metrics of a strategy.
 
     Parameters
@@ -703,9 +767,6 @@ def perf_stats_bootstrap(returns, factor_returns=None, positions=None,
         Daily noncumulative returns of the benchmark.
          - This is in the same style as returns.
         If None, do not compute alpha, beta, and information ratio.
-    positions : pd.DataFrame
-        Daily net position values.
-         - See full explanation in tears.create_full_tear_sheet.
     return_stats : boolean (optional)
         If True, returns a DataFrame of mean, median, 5 and 95 percentiles
         for each perf metric.
@@ -725,17 +786,13 @@ def perf_stats_bootstrap(returns, factor_returns=None, positions=None,
     bootstrap_values = OrderedDict()
 
     for stat_func in SIMPLE_STAT_FUNCS:
-        stat_name = stat_func.__name__
+        stat_name = STAT_FUNC_NAMES[stat_func.__name__]
         bootstrap_values[stat_name] = calc_bootstrap(stat_func,
                                                      returns)
 
-    if positions is not None:
-        gl = gross_lev(positions)
-        bootstrap_values['gross_leverage'] = calc_bootstrap(np.mean, gl)
-
     if factor_returns is not None:
         for stat_func in FACTOR_STAT_FUNCS:
-            stat_name = stat_func.__name__
+            stat_name = STAT_FUNC_NAMES[stat_func.__name__]
             bootstrap_values[stat_name] = calc_bootstrap(
                 stat_func,
                 returns,
@@ -946,35 +1003,35 @@ def gen_drawdown_table(returns, top=10):
     df_cum = cum_returns(returns, 1.0)
     drawdown_periods = get_top_drawdowns(returns, top=top)
     df_drawdowns = pd.DataFrame(index=list(range(top)),
-                                columns=['net drawdown in %',
-                                         'peak date',
-                                         'valley date',
-                                         'recovery date',
-                                         'duration'])
+                                columns=['Net drawdown in %',
+                                         'Peak date',
+                                         'Valley date',
+                                         'Recovery date',
+                                         'Duration'])
 
     for i, (peak, valley, recovery) in enumerate(drawdown_periods):
         if pd.isnull(recovery):
-            df_drawdowns.loc[i, 'duration'] = np.nan
+            df_drawdowns.loc[i, 'Duration'] = np.nan
         else:
-            df_drawdowns.loc[i, 'duration'] = len(pd.date_range(peak,
+            df_drawdowns.loc[i, 'Duration'] = len(pd.date_range(peak,
                                                                 recovery,
                                                                 freq='B'))
-        df_drawdowns.loc[i, 'peak date'] = (peak.to_pydatetime()
+        df_drawdowns.loc[i, 'Peak date'] = (peak.to_pydatetime()
                                             .strftime('%Y-%m-%d'))
-        df_drawdowns.loc[i, 'valley date'] = (valley.to_pydatetime()
+        df_drawdowns.loc[i, 'Valley date'] = (valley.to_pydatetime()
                                               .strftime('%Y-%m-%d'))
         if isinstance(recovery, float):
-            df_drawdowns.loc[i, 'recovery date'] = recovery
+            df_drawdowns.loc[i, 'Recovery date'] = recovery
         else:
-            df_drawdowns.loc[i, 'recovery date'] = (recovery.to_pydatetime()
+            df_drawdowns.loc[i, 'Recovery date'] = (recovery.to_pydatetime()
                                                     .strftime('%Y-%m-%d'))
-        df_drawdowns.loc[i, 'net drawdown in %'] = (
+        df_drawdowns.loc[i, 'Net drawdown in %'] = (
             (df_cum.loc[peak] - df_cum.loc[valley]) / df_cum.loc[peak]) * 100
 
-    df_drawdowns['peak date'] = pd.to_datetime(df_drawdowns['peak date'])
-    df_drawdowns['valley date'] = pd.to_datetime(df_drawdowns['valley date'])
-    df_drawdowns['recovery date'] = pd.to_datetime(
-        df_drawdowns['recovery date'])
+    df_drawdowns['Peak date'] = pd.to_datetime(df_drawdowns['Peak date'])
+    df_drawdowns['Valley date'] = pd.to_datetime(df_drawdowns['Valley date'])
+    df_drawdowns['Recovery date'] = pd.to_datetime(
+        df_drawdowns['Recovery date'])
 
     return df_drawdowns
 

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -696,6 +696,7 @@ STAT_FUNC_NAMES = {
     'beta': 'Beta',
 }
 
+
 def perf_stats(returns, factor_returns=None, positions=None,
                transactions=None):
     """

--- a/pyfolio/txn.py
+++ b/pyfolio/txn.py
@@ -175,7 +175,10 @@ def get_turnover(positions, transactions, period=None, average=True):
         portfolio_value = portfolio_value.resample(period).mean()
     # traded_value contains the summed value from buys and sells;
     # this is divided by 2.0 to get the average of the two.
-    turnover = traded_value / 2.0 if average else traded_value
+    if average:
+        turnover = traded_value / 2.0
+    else:
+        turnover = traded_value
     turnover_rate = turnover.div(portfolio_value, axis='index')
     turnover_rate = turnover_rate.fillna(0)
     return turnover_rate


### PR DESCRIPTION
 * Take out information ratio from the performance statistics table, and add variance at risk and daily turnover. Also, use complete name of statistic (not just of the function) and add some percentage signs:
![screen shot 2017-04-20 at 3 39 51 pm](https://cloud.githubusercontent.com/assets/1934957/25249728/ed184b4c-25e0-11e7-9b51-f0328d4b725a.png)

 * Show min and max holdings in legend of long+short holdings plot.
 * Also some minor refactorings and doc fixes.