### PR TITLE
BLD: Install ipython<6 for Python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import sys
 from setuptools import setup
 
 import versioneer
@@ -38,8 +39,13 @@ classifiers = ['Development Status :: 4 - Beta',
                'Topic :: Scientific/Engineering :: Mathematics',
                'Operating System :: OS Independent']
 
+if (sys.version_info.major, sys.version_info.minor) >= (3, 3):
+    support_ipython_6 = True
+else:
+    support_ipython_6 = False
+
 install_reqs = [
-    'ipython>=3.2.3',
+    'ipython>=3.2.3' if support_ipython_6 else 'ipython>=3.2.3, <6',
     'matplotlib>=1.4.0',
     'numpy>=1.9.1',
     'pandas>=0.19.0',


### PR DESCRIPTION
I find the issue when installing pyfolio in an environment where ipython is not installed:

```
Collecting ipython>=3.2.3 (from pyfolio==0.7.0)
  Downloading https://pypi.tuna.tsinghua.edu.cn/packages/75/03/bb1ce0cf9f8a86f52b34090708e1806bc11e2d29b193e7d6fe0afe9a61e5/ipython-6.0.0.tar.gz (5.1MB)
    Complete output from command python setup.py egg_info:

    IPython 6.0+ does not support Python 2.6, 2.7, 3.0, 3.1, or 3.2.
    When using Python 2.7, please install IPython 5.x LTS Long Term Support version.
    Beginning with IPython 6.0, Python 3.3 and above is required.

    See IPython `README.rst` file for more information:

        https://github.com/ipython/ipython/blob/master/README.rst

    Python sys.version_info(major=2, minor=7, micro=12, releaselevel='final', serial=0) detected.



    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-JYfhfE/ipython/
```