### PR TITLE
Fix Fama-French for short time periods

### DIFF
--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -583,7 +583,7 @@ def rolling_fama_french(returns, factor_returns=None,
     factor_returns['const'] = 1
 
     # have NaNs when there is insufficient data to do a regression
-    regression_coeffs = np.empty((rolling_window,
+    regression_coeffs = np.empty((min(rolling_window, len(factor_returns)),
                                   len(factor_returns.columns)))
     regression_coeffs.fill(np.nan)
 


### PR DESCRIPTION
Use minimum of rolling window and factor returns when constructing DataFrame for FFF. This is significant for algos with less than 8 (not 6!) months of recent data, because the daily factors on French's Dartmouth site are ~2 months out of date (which is where pandas grabs them from): http://mba.tuck.dartmouth.edu/pages/faculty/ken.french/data_library.html