### PR TITLE
DOC: Remove unused var & add txns to create_position_tear_sheet

### DIFF
--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -614,7 +614,8 @@ def create_position_tear_sheet(returns, positions,
         Security identifier to sector mapping.
         Security ids as keys, sectors as values.
     transactions : pd.DataFrame, optional
-        Daily transactions.
+        Prices and amounts of executed trades. One row per trade.
+         - See full explanation in create_full_tear_sheet.
     estimate_intraday: boolean or str, optional
         Approximate returns for intraday strategies.
         See description in create_full_tear_sheet.

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -610,11 +610,11 @@ def create_position_tear_sheet(returns, positions,
         Overrides show_and_plot_top_pos to 0 to suppress text output.
     return_fig : boolean, optional
         If True, returns the figure that was plotted on.
-    set_context : boolean, optional
-        If True, set default plotting style context.
     sector_mappings : dict or pd.Series, optional
         Security identifier to sector mapping.
         Security ids as keys, sectors as values.
+    transactions : pd.DataFrame, optional
+        Daily transactions.
     estimate_intraday: boolean or str, optional
         Approximate returns for intraday strategies.
         See description in create_full_tear_sheet.


### PR DESCRIPTION
I couldn't find any usage of `set_context` in `create_position_tear_sheet` so I removed it and also added info in the docstring for `transactions`.