### PR TITLE
Allow users to provide extra rows in the top table

### DIFF
--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -654,8 +654,9 @@ def show_perf_stats(returns, factor_returns, positions=None,
         turnover_denom=turnover_denom)
 
     date_rows = OrderedDict()
-    date_rows['Start date'] = returns.index[0].strftime('%Y-%m-%d')
-    date_rows['End date'] = returns.index[-1].strftime('%Y-%m-%d')
+    if len(returns.index) > 0:
+        date_rows['Start date'] = returns.index[0].strftime('%Y-%m-%d')
+        date_rows['End date'] = returns.index[-1].strftime('%Y-%m-%d')
 
     if live_start_date is not None:
         live_start_date = ep.utils.get_utc_timestamp(live_start_date)
@@ -689,11 +690,11 @@ def show_perf_stats(returns, factor_returns, positions=None,
             positions=positions_oos,
             transactions=transactions_oos,
             turnover_denom=turnover_denom)
-
-        date_rows['In-sample months'] = int(len(returns_is) /
-                                            APPROX_BDAYS_PER_MONTH)
-        date_rows['Out-of-sample months'] = int(len(returns_oos) /
+        if len(returns.index) > 0:
+            date_rows['In-sample months'] = int(len(returns_is) /
                                                 APPROX_BDAYS_PER_MONTH)
+            date_rows['Out-of-sample months'] = int(len(returns_oos) /
+                                                    APPROX_BDAYS_PER_MONTH)
 
         perf_stats = pd.concat(OrderedDict([
             ('In-sample', perf_stats_is),
@@ -701,8 +702,9 @@ def show_perf_stats(returns, factor_returns, positions=None,
             ('All', perf_stats_all),
         ]), axis=1)
     else:
-        date_rows['Total months'] = int(len(returns) /
-                                        APPROX_BDAYS_PER_MONTH)
+        if len(returns.index) > 0:
+            date_rows['Total months'] = int(len(returns) /
+                                            APPROX_BDAYS_PER_MONTH)
         perf_stats = pd.DataFrame(perf_stats_all, columns=['Backtest'])
 
     for column in perf_stats.columns:

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -81,7 +81,7 @@ def create_full_tear_sheet(returns,
                            factor_returns=None,
                            factor_loadings=None,
                            pos_in_dollars=True,
-                           return_fig=False):
+                           header_rows=None):
     """
     Generate a number of tear sheets that are useful
     for analyzing a strategy's performance.
@@ -161,9 +161,6 @@ def create_full_tear_sheet(returns,
     turnover_denom : str
         Either AGB or portfolio_value, default AGB.
         - See full explanation in txn.get_turnover.
-    set_context : boolean, optional
-        If True, set default plotting style context.
-         - See plotting.context().
     factor_returns : pd.Dataframe, optional
         Returns by factor, with date as index and factors as columns
     factor_loadings : pd.Dataframe, optional
@@ -171,6 +168,11 @@ def create_full_tear_sheet(returns,
         ticker as index, and factors as columns.
     pos_in_dollars : boolean, optional
         indicates whether positions is in dollars
+    header_rows : dict or OrderedDict, optional
+        Extra rows to display at the top of the perf stats table.
+    set_context : boolean, optional
+        If True, set default plotting style context.
+         - See plotting.context().
     """
 
     if benchmark_rets is None:
@@ -194,6 +196,7 @@ def create_full_tear_sheet(returns,
         benchmark_rets=benchmark_rets,
         bootstrap=bootstrap,
         turnover_denom=turnover_denom,
+        header_rows=header_rows,
         set_context=set_context)
 
     create_interesting_times_tear_sheet(returns,
@@ -242,6 +245,7 @@ def create_full_tear_sheet(returns,
                                    set_context=set_context)
 
 
+@plotting.customize
 def create_simple_tear_sheet(returns,
                              positions=None,
                              transactions=None,
@@ -249,7 +253,8 @@ def create_simple_tear_sheet(returns,
                              slippage=None,
                              estimate_intraday='infer',
                              live_start_date=None,
-                             turnover_denom='AGB'):
+                             turnover_denom='AGB',
+                             header_rows=None):
     """
     Simpler version of create_full_tear_sheet; generates summary performance
     statistics and important plots as a single image.
@@ -306,9 +311,13 @@ def create_simple_tear_sheet(returns,
     live_start_date : datetime, optional
         The point in time when the strategy began live trading,
         after its backtest period. This datetime should be normalized.
-    turnover_denom : str
+    turnover_denom : str, optional
         Either AGB or portfolio_value, default AGB.
         - See full explanation in txn.get_turnover.
+    header_rows : dict or OrderedDict, optional
+        Extra rows to display at the top of the perf stats table.
+    set_context : boolean, optional
+        If True, set default plotting style context.
     """
 
     positions = utils.check_intraday(estimate_intraday, returns,
@@ -331,14 +340,13 @@ def create_simple_tear_sheet(returns,
     # Plot simple returns tear sheet
     returns = returns[returns.index > benchmark_rets.index[0]]
 
-    print("Entire data start date: %s" % returns.index[0].strftime('%Y-%m-%d'))
-    print("Entire data end date: %s" % returns.index[-1].strftime('%Y-%m-%d'))
     plotting.show_perf_stats(returns,
                              benchmark_rets,
                              positions=positions,
                              transactions=transactions,
                              turnover_denom=turnover_denom,
-                             live_start_date=live_start_date)
+                             live_start_date=live_start_date,
+                             header_rows=header_rows)
 
     if returns.index[0] < benchmark_rets.index[0]:
         returns = returns[returns.index > benchmark_rets.index[0]]
@@ -426,6 +434,7 @@ def create_returns_tear_sheet(returns, positions=None,
                               benchmark_rets=None,
                               bootstrap=False,
                               turnover_denom='AGB',
+                              header_rows=None,
                               return_fig=False):
     """
     Generate a number of plots for analyzing a strategy's returns.
@@ -457,12 +466,14 @@ def create_returns_tear_sheet(returns, positions=None,
     benchmark_rets : pd.Series, optional
         Daily noncumulative returns of the benchmark.
          - This is in the same style as returns.
-    bootstrap : boolean (optional)
+    bootstrap : boolean, optional
         Whether to perform bootstrap analysis for the performance
         metrics. Takes a few minutes longer.
-    turnover_denom : str
+    turnover_denom : str, optional
         Either AGB or portfolio_value, default AGB.
         - See full explanation in txn.get_turnover.
+    header_rows : dict or OrderedDict, optional
+        Extra rows to display at the top of the perf stats table.
     return_fig : boolean, optional
         If True, returns the figure that was plotted on.
     set_context : boolean, optional
@@ -474,15 +485,13 @@ def create_returns_tear_sheet(returns, positions=None,
 
     returns = returns[returns.index > benchmark_rets.index[0]]
 
-    print("Entire data start date: %s" % returns.index[0].strftime('%Y-%m-%d'))
-    print("Entire data end date: %s" % returns.index[-1].strftime('%Y-%m-%d'))
-
     plotting.show_perf_stats(returns, benchmark_rets,
                              positions=positions,
                              transactions=transactions,
                              turnover_denom=turnover_denom,
                              bootstrap=bootstrap,
-                             live_start_date=live_start_date)
+                             live_start_date=live_start_date,
+                             header_rows=header_rows)
 
     plotting.show_worst_drawdown_periods(returns)
 

--- a/pyfolio/utils.py
+++ b/pyfolio/utils.py
@@ -19,7 +19,7 @@ import warnings
 
 import numpy as np
 import pandas as pd
-from IPython.display import display
+from IPython.display import display, HTML
 
 import empyrical.utils
 from os import environ
@@ -178,7 +178,7 @@ def extract_rets_pos_txn_from_zipline(backtest):
     return returns, positions, transactions
 
 
-def print_table(table, name=None, fmt=None):
+def print_table(table, name=None, fmt=None, header_rows=None):
     """
     Pretty print a pandas DataFrame.
 
@@ -207,7 +207,21 @@ def print_table(table, name=None, fmt=None):
     if name is not None:
         table.columns.name = name
 
-    display(table)
+    html = table.to_html()
+    if header_rows is not None:
+        # Count the number of columns for the text to span
+        n_cols = html.split('<thead>')[1].split('</thead>')[0].count('<th>')
+
+        # Generate the HTML for the extra rows
+        rows = ''
+        for name, value in header_rows.items():
+            rows += ('\n    <tr style="text-align: right;"><th>%s</th>' +
+                     '<td colspan=%d>%s</td></tr>') % (name, n_cols, value)
+
+        # Inject the new HTML
+        html = html.replace('<thead>', '<thead>' + rows)
+
+    display(HTML(html))
 
     if fmt is not None:
         pd.set_option('display.float_format', prev_option)


### PR DESCRIPTION
This allows users to pass in extra rows (as a `dict` or `OrderedDict`) to display in the perf_stats table. They can pass `header_rows` to `create_full_tear_sheet`, `create_simple_tear_sheet`, `create_returns_tear_sheet`, `show_perf_stats`, and `print_table`. HTML will be generated and injected into the top of the table. Also puts the dates/ranges here, below the rows that the user passes.

Also clean up a few random doc strings.

Examples:
![screen shot 2017-09-27 at 1 14 14 pm](https://user-images.githubusercontent.com/1934957/30927224-cb998968-a385-11e7-9fe6-3131667b28c9.png)


![2](https://user-images.githubusercontent.com/1934957/30927128-6497caae-a385-11e7-90a3-cc027c5e16c0.png)
