### PR TITLE
MAINT: update perf attrib summary table

### DIFF
--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -171,22 +171,24 @@ def create_perf_attrib_stats(perf_attrib, risk_exposures):
     specific_returns = perf_attrib['specific_returns']
     common_returns = perf_attrib['common_returns']
 
-    summary['Annual multi-factor alpha'] =\
+    summary['Annualized Specific Return'] =\
         ep.annual_return(specific_returns)
+    summary['Annualized Common Return'] =\
+        ep.annual_return(common_returns)
+    summary['Total Annualized Return'] =\
+        ep.annual_return(perf_attrib['total_returns'])
 
-    summary['Multi-factor sharpe'] =\
+    summary['Specific Sharpe Ratio'] =\
         ep.sharpe_ratio(specific_returns)
 
-    # empty line between common/specific/total returns
-    summary[' '] = ' '
-    summary['Cumulative specific returns'] =\
+    summary['Cumulative Specific Return'] =\
         ep.cum_returns_final(specific_returns)
-    summary['Cumulative common returns'] =\
+    summary['Cumulative Common Return'] =\
         ep.cum_returns_final(common_returns)
-    summary['Total returns'] =\
-        ep.cum_returns_final(total_returns)
+    summary['Total Returns'] =\
+        ep.cum_returns_final(perf_attrib['total_returns'])
 
-    summary = pd.Series(summary)
+    summary = pd.Series(summary, name='Summary Statistics')
 
     risk_exposure_summary = pd.DataFrame(
         data={'Annualized Return': ep.annual_return(total_returns),
@@ -216,7 +218,11 @@ def show_perf_attrib_stats(returns, positions, factor_returns,
     perf_attrib_stats, risk_exposure_stats =\
         create_perf_attrib_stats(perf_attrib_data, risk_exposures)
 
-    print_table(perf_attrib_stats)
+    print_table(perf_attrib_stats.loc[['Annualized Specific Return',
+                                       'Annualized Common Return',
+                                       'Total Annualized Return']])
+
+    print_table(perf_attrib_stats[['Specific Sharpe Ratio']])
     print_table(risk_exposure_stats)
 
 

--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -176,7 +176,7 @@ def create_perf_attrib_stats(perf_attrib, risk_exposures):
     summary['Annualized Common Return'] =\
         ep.annual_return(common_returns)
     summary['Total Annualized Return'] =\
-        ep.annual_return(perf_attrib['total_returns'])
+        ep.annual_return(total_returns)
 
     summary['Specific Sharpe Ratio'] =\
         ep.sharpe_ratio(specific_returns)
@@ -186,9 +186,9 @@ def create_perf_attrib_stats(perf_attrib, risk_exposures):
     summary['Cumulative Common Return'] =\
         ep.cum_returns_final(common_returns)
     summary['Total Returns'] =\
-        ep.cum_returns_final(perf_attrib['total_returns'])
+        ep.cum_returns_final(total_returns)
 
-    summary = pd.Series(summary, name='Summary Statistics')
+    summary = pd.Series(summary, name='')
 
     annualized_returns_by_factor = [ep.annual_return(perf_attrib[c])
                                     for c in risk_exposures.columns]
@@ -225,10 +225,11 @@ def show_perf_attrib_stats(returns, positions, factor_returns,
 
     print_table(perf_attrib_stats.loc[['Annualized Specific Return',
                                        'Annualized Common Return',
-                                       'Total Annualized Return']])
+                                       'Total Annualized Return']],
+                name='Summary Statistics')
 
     print_table(perf_attrib_stats[['Specific Sharpe Ratio']])
-    print_table(risk_exposure_stats)
+    print_table(risk_exposure_stats, name='Exposures Summary')
 
 
 def plot_returns(perf_attrib_data, cost=None, ax=None):

--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -190,9 +190,14 @@ def create_perf_attrib_stats(perf_attrib, risk_exposures):
 
     summary = pd.Series(summary, name='Summary Statistics')
 
+    annualized_returns_by_factor = [ep.annual_return(perf_attrib[c])
+                                    for c in risk_exposures.columns]
+    cumulative_returns_by_factor = [ep.cum_returns_final(perf_attrib[c])
+                                    for c in risk_exposures.columns]
+
     risk_exposure_summary = pd.DataFrame(
-        data={'Annualized Return': ep.annual_return(total_returns),
-              'Cumulative Return': ep.cum_returns(total_returns),
+        data={'Annualized Return': annualized_returns_by_factor,
+              'Cumulative Return': cumulative_returns_by_factor,
               'Average Risk Factor Exposure':
               risk_exposures.mean(axis='rows')},
         index=risk_exposures.columns,

--- a/pyfolio/tests/test_perf_attrib.py
+++ b/pyfolio/tests/test_perf_attrib.py
@@ -155,6 +155,24 @@ class PerfAttribTestCase(unittest.TestCase):
         pd.util.testing.assert_frame_equal(expected_exposures_portfolio,
                                            exposures_portfolio)
 
+        perf_attrib_summary, exposures_summary = create_perf_attrib_stats(
+            perf_attrib_output, exposures_portfolio
+        )
+
+        self.assertEqual(perf_attrib_summary['Annualized Specific Return'],
+                         perf_attrib_summary['Total Annualized Return'])
+
+        self.assertEqual(perf_attrib_summary['Cumulative Specific Return'],
+                         perf_attrib_summary['Total Returns'])
+
+        pd.util.testing.assert_frame_equal(
+            exposures_summary,
+            pd.DataFrame(0.0, index=['risk_factor1', 'risk_factor2'],
+                         columns=['Annualized Return',
+                                  'Average Risk Factor Exposure',
+                                  'Cumulative Return'])
+        )
+
     def test_perf_attrib_regression(self):
 
         positions = pd.read_csv('pyfolio/tests/test_data/positions.csv',

--- a/pyfolio/tests/test_perf_attrib.py
+++ b/pyfolio/tests/test_perf_attrib.py
@@ -266,8 +266,8 @@ class PerfAttribTestCase(unittest.TestCase):
         cumulative_returns_by_factor = pd.Series(
             [ep.cum_returns_final(perf_attrib_output[c])
              for c in risk_exposures_portfolio.columns],
-             name='Cumulative Return',
-             index=risk_exposures_portfolio.columns
+            name='Cumulative Return',
+            index=risk_exposures_portfolio.columns
         )
 
         pd.util.testing.assert_series_equal(

--- a/pyfolio/tests/test_perf_attrib.py
+++ b/pyfolio/tests/test_perf_attrib.py
@@ -235,19 +235,25 @@ class PerfAttribTestCase(unittest.TestCase):
         )
 
         self.assertEqual(ep.annual_return(specific_returns),
-                         perf_attrib_summary['Annual multi-factor alpha'])
+                         perf_attrib_summary['Annualized Specific Return'])
+
+        self.assertEqual(ep.annual_return(common_returns),
+                         perf_attrib_summary['Annualized Common Return'])
+
+        self.assertEqual(ep.annual_return(combined_returns),
+                         perf_attrib_summary['Total Annualized Return'])
 
         self.assertEqual(ep.sharpe_ratio(specific_returns),
-                         perf_attrib_summary['Multi-factor sharpe'])
+                         perf_attrib_summary['Specific Sharpe Ratio'])
 
         self.assertEqual(ep.cum_returns_final(specific_returns),
-                         perf_attrib_summary['Cumulative specific returns'])
+                         perf_attrib_summary['Cumulative Specific Return'])
 
         self.assertEqual(ep.cum_returns_final(common_returns),
-                         perf_attrib_summary['Cumulative common returns'])
+                         perf_attrib_summary['Cumulative Common Return'])
 
         self.assertEqual(ep.cum_returns_final(combined_returns),
-                         perf_attrib_summary['Total returns'])
+                         perf_attrib_summary['Total Returns'])
 
         avg_factor_exposure = risk_exposures_portfolio.mean().rename(
             'Average Risk Factor Exposure'
@@ -255,6 +261,30 @@ class PerfAttribTestCase(unittest.TestCase):
         pd.util.testing.assert_series_equal(
             avg_factor_exposure,
             exposures_summary['Average Risk Factor Exposure']
+        )
+
+        cumulative_returns_by_factor = pd.Series(
+            [ep.cum_returns_final(perf_attrib_output[c])
+             for c in risk_exposures_portfolio.columns],
+             name='Cumulative Return',
+             index=risk_exposures_portfolio.columns
+        )
+
+        pd.util.testing.assert_series_equal(
+            cumulative_returns_by_factor,
+            exposures_summary['Cumulative Return']
+        )
+
+        annualized_returns_by_factor = pd.Series(
+            [ep.annual_return(perf_attrib_output[c])
+             for c in risk_exposures_portfolio.columns],
+            name='Annualized Return',
+            index=risk_exposures_portfolio.columns
+        )
+
+        pd.util.testing.assert_series_equal(
+            annualized_returns_by_factor,
+            exposures_summary['Annualized Return']
         )
 
     def test_missing_stocks_and_dates(self):


### PR DESCRIPTION
update summary table to be of the format: 
```
Summary statistics:
Annualized Specific Return (Alpha): x%
Annualized Common Return (Beta): y%
Total Annualized Return: A%

Specific Sharpe Ratio: x%/std.dev()
```
annualized cost to be added later on.

cc @joshpayne 