### PR TITLE
MAINT: ignore errors when dropping indexes

### DIFF
--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -117,7 +117,8 @@ def perf_attrib(returns, positions, factor_returns, factor_loadings,
                               num_stocks,
                               positions[missing_stocks].mean()))
 
-        positions = positions.drop(missing_stocks, axis='columns')
+        positions = positions.drop(missing_stocks, axis='columns',
+                                   errors='ignore')
 
     missing_factor_loadings_index = positions.index.difference(
         factor_loadings.index.get_level_values(0).unique()
@@ -129,9 +130,11 @@ def perf_attrib(returns, positions, factor_returns, factor_loadings,
                       "Truncating date range for performance attribution. "
                       .format(list(missing_factor_loadings_index)))
 
-        positions = positions.drop(missing_factor_loadings_index)
-        returns = returns.drop(missing_factor_loadings_index)
-        factor_returns = factor_returns.drop(missing_factor_loadings_index)
+        positions = positions.drop(missing_factor_loadings_index,
+                                   errors='ignore')
+        returns = returns.drop(missing_factor_loadings_index, errors='ignore')
+        factor_returns = factor_returns.drop(missing_factor_loadings_index,
+                                             errors='ignore')
 
     if pos_in_dollars:
         # convert holdings to percentages

--- a/pyfolio/tests/test_perf_attrib.py
+++ b/pyfolio/tests/test_perf_attrib.py
@@ -269,6 +269,22 @@ class PerfAttribTestCase(unittest.TestCase):
                 self.assertNotIn(date, exposures.index)
                 self.assertNotIn(date, perf_attrib_data.index)
 
+            # perf attrib should work if factor_returns already missing dates
+            exposures, perf_attrib_data = perf_attrib(
+                returns,
+                positions,
+                factor_returns.drop(pd.DatetimeIndex(missing_dates)),
+                factor_loadings_missing_dates
+            )
+
+            self.assertEqual(len(w), 3)
+            self.assertIn("Could not find factor loadings for "
+                          "the dates", str(w[-1].message))
+
+            for date in missing_dates:
+                self.assertNotIn(date, exposures.index)
+                self.assertNotIn(date, perf_attrib_data.index)
+
             # test missing stocks and dates
             factor_loadings_missing_both =\
                 factor_loadings_missing_dates.drop('TLT', level='ticker')
@@ -279,7 +295,7 @@ class PerfAttribTestCase(unittest.TestCase):
                             factor_returns,
                             factor_loadings_missing_both)
 
-            self.assertEqual(len(w), 4)
+            self.assertEqual(len(w), 5)
             self.assertIn("Could not find factor loadings for the following "
                           "stocks: ['TLT']", str(w[-2].message))
             self.assertIn("Coverage ratio: 2/3", str(w[-2].message))


### PR DESCRIPTION
Ignore errors when dropping indexes so that `perf_attrib` doesn't crash if an input is already missing those indexes.