### PR TITLE
MAINT: don't do perf attrib if no factor loadings

### DIFF
--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -105,6 +105,12 @@ def perf_attrib(returns, positions, factor_returns, factor_loadings,
     # cash will not be in factor_loadings
     num_stocks = len(positions.columns) - 1
     missing_stocks = missing_stocks.drop('cash')
+    num_stocks_covered = num_stocks - len(missing_stocks)
+
+    if num_stocks_covered == 0:
+        raise ValueError("Could not perform performance attribution. "
+                         "No factor loadings were available for this "
+                         "algorithm's positions.")
 
     if len(missing_stocks) > 0:
 
@@ -113,7 +119,7 @@ def perf_attrib(returns, positions, factor_returns, factor_loadings,
                       "performance attribution. Coverage ratio: {}/{}. "
                       "Average allocation of missing stocks: {} "
                       .format(list(missing_stocks),
-                              num_stocks - len(missing_stocks),
+                              num_stocks_covered,
                               num_stocks,
                               positions[missing_stocks].mean()))
 

--- a/pyfolio/tests/test_perf_attrib.py
+++ b/pyfolio/tests/test_perf_attrib.py
@@ -333,3 +333,17 @@ class PerfAttribTestCase(unittest.TestCase):
             for date in missing_dates:
                 self.assertNotIn(date, exposures.index)
                 self.assertNotIn(date, perf_attrib_data.index)
+
+            # raise exception if all stocks are filtered out
+            empty_factor_loadings = factor_loadings.drop(
+                ['AAPL', 'TLT', 'XOM'], level='ticker'
+            )
+
+            with self.assertRaisesRegexp(ValueError,
+                                         "No factor loadings were available"):
+
+                exposures, perf_attrib_data =\
+                    perf_attrib(returns,
+                                positions,
+                                factor_returns,
+                                empty_factor_loadings)


### PR DESCRIPTION
If there are no factor loadings for any positions, show a warning and exit