### PR TITLE
Improve warnings before perf attribution

### DIFF
--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -82,7 +82,10 @@ def perf_attrib(returns,
                        XOM    -1.798401  0.761549
 
     transactions : pd.DataFrame, optional
-        Executed trade volumes and fill prices.
+        Executed trade volumes and fill prices. Used to check the turnover of
+        the algorithm. Default is None, in which case the turnover check is
+        skipped.
+
         - One row per trade.
         - Trades on different names that occur at the
           same time will have identical indicies.
@@ -91,8 +94,6 @@ def perf_attrib(returns,
             2004-01-09 12:18:01    483      324.12   'AAPL'
             2004-01-09 12:18:01    122      83.10    'MSFT'
             2004-01-13 14:12:23    -75      340.43   'AAPL'
-        - Used to check the turnover of the algorithm.
-        - Default is None, in which case the turnover check is skipped.
 
     pos_in_dollars : bool
         Flag indicating whether `positions` are in dollars or percentages

--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -128,7 +128,7 @@ def perf_attrib(returns,
     num_stocks = len(positions.columns) - 1
     missing_stocks = missing_stocks.drop('cash')
     num_stocks_covered = num_stocks - len(missing_stocks)
-    coverage_ratio = (num_stocks - len(missing_stocks)) / num_stocks
+    missing_ratio = len(missing_stocks) / num_stocks
 
     if num_stocks_covered == 0:
         raise ValueError("Could not perform performance attribution. "
@@ -150,7 +150,7 @@ def perf_attrib(returns,
             "{}.\n"
         ).format(
             list(missing_stocks),
-            coverage_ratio,
+            missing_ratio,
             positions[missing_stocks].mean(),
         )
 

--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -139,7 +139,7 @@ def perf_attrib(returns,
 
         missing_stocks_warning_msg = (
             "Could not determine risk exposures for some of this algorithm's "
-            "positions. PnL from the missing assets will not be properly "
+            "positions. Returns from the missing assets will not be properly "
             "accounted for in performance attribution.\n"
             "\n"
             "The following assets were missing factor loadings: {}. "

--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -127,6 +127,7 @@ def perf_attrib(returns,
     num_stocks = len(positions.columns) - 1
     missing_stocks = missing_stocks.drop('cash')
     num_stocks_covered = num_stocks - len(missing_stocks)
+    coverage_ratio = (num_stocks - len(missing_stocks)) / num_stocks
 
     if num_stocks_covered == 0:
         raise ValueError("Could not perform performance attribution. "
@@ -135,14 +136,24 @@ def perf_attrib(returns,
 
     if len(missing_stocks) > 0:
 
-        warnings.warn("Could not find factor loadings for the following "
-                      "stocks: {}. Ignoring for exposure calculation and "
-                      "performance attribution. Coverage ratio: {}/{}. "
-                      "Average allocation of missing stocks: {} "
-                      .format(list(missing_stocks),
-                              num_stocks_covered,
-                              num_stocks,
-                              positions[missing_stocks].mean()))
+        missing_stocks_warning_msg = (
+            "Could not determine risk exposures for some of this algorithm's "
+            "positions. PnL from the missing assets will not be properly "
+            "accounted for in performance attribution.\n"
+            "\n"
+            "The following assets were missing factor loadings: {}. "
+            "Ignoring for exposure calculation and performance attribution. "
+            "Ratio of assets missing: {}. Average allocation of missing "
+            "assets:\n"
+            "\n"
+            "{}.\n"
+        ).format(
+            list(missing_stocks),
+            coverage_ratio,
+            positions[missing_stocks].mean(),
+        )
+
+        warnings.warn(missing_stocks_warning_msg)
 
         positions = positions.drop(missing_stocks, axis='columns',
                                    errors='ignore')

--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -128,7 +128,7 @@ def perf_attrib(returns,
     num_stocks = len(positions.columns) - 1
     missing_stocks = missing_stocks.drop('cash')
     num_stocks_covered = num_stocks - len(missing_stocks)
-    missing_ratio = len(missing_stocks) / num_stocks
+    missing_ratio = round(len(missing_stocks) / num_stocks, ndigits=3)
 
     if num_stocks_covered == 0:
         raise ValueError("Could not perform performance attribution. "

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -235,7 +235,7 @@ def create_full_tear_sheet(returns,
 
         if factor_returns is not None and factor_loadings is not None:
             create_perf_attrib_tear_sheet(returns, positions, factor_returns,
-                                          factor_loadings,
+                                          factor_loadings, transactions,
                                           pos_in_dollars=pos_in_dollars)
 
     if bayesian:
@@ -1469,6 +1469,7 @@ def create_perf_attrib_tear_sheet(returns,
                                   positions,
                                   factor_returns,
                                   factor_loadings,
+                                  transactions=None,
                                   pos_in_dollars=True,
                                   return_fig=False):
     """
@@ -1491,6 +1492,11 @@ def create_perf_attrib_tear_sheet(returns,
         Factor loadings for all days in the date range, with date
         and ticker as index, and factors as columns.
 
+    transactions : pd.DataFrame, optional
+        Prices and amounts of executed trades. One row per trade.
+         - See full explanation in create_full_tear_sheet.
+         - Default is None.
+
     pos_in_dollars : boolean, optional
         Flag indicating whether `positions` are in dollars or percentages
         If True, positions are in dollars.
@@ -1499,13 +1505,13 @@ def create_perf_attrib_tear_sheet(returns,
         If True, returns the figure that was plotted on.
     """
     portfolio_exposures, perf_attrib_data = perf_attrib.perf_attrib(
-        returns, positions, factor_returns, factor_loadings,
+        returns, positions, factor_returns, factor_loadings, transactions,
         pos_in_dollars=pos_in_dollars
     )
 
     # aggregate perf attrib stats and show summary table
     perf_attrib.show_perf_attrib_stats(returns, positions, factor_returns,
-                                       factor_loadings)
+                                       factor_loadings, transactions)
 
     vertical_sections = 3
     fig = plt.figure(figsize=[14, vertical_sections * 6])

--- a/pyfolio/tests/test_perf_attrib.py
+++ b/pyfolio/tests/test_perf_attrib.py
@@ -323,9 +323,9 @@ class PerfAttribTestCase(unittest.TestCase):
                         factor_loadings_missing_stocks)
 
             self.assertEqual(len(w), 1)
-            self.assertIn("Could not find factor loadings for the following "
-                          "stocks: ['TLT']", str(w[-1].message))
-            self.assertIn("Coverage ratio: 2/3", str(w[-1].message))
+            self.assertIn("The following assets were missing factor loadings: "
+                          "['TLT']", str(w[-1].message))
+            self.assertIn("Ratio of assets missing: 0.333", str(w[-1].message))
 
             # missing dates should raise a warning
             missing_dates = ['2017-01-01', '2017-01-05']
@@ -372,9 +372,9 @@ class PerfAttribTestCase(unittest.TestCase):
                             factor_loadings_missing_both)
 
             self.assertEqual(len(w), 5)
-            self.assertIn("Could not find factor loadings for the following "
-                          "stocks: ['TLT']", str(w[-2].message))
-            self.assertIn("Coverage ratio: 2/3", str(w[-2].message))
+            self.assertIn("The following assets were missing factor loadings: "
+                          "['TLT']", str(w[-2].message))
+            self.assertIn("Ratio of assets missing: 0.333", str(w[-2].message))
 
             self.assertIn("Could not find factor loadings for "
                           "the dates", str(w[-1].message))


### PR DESCRIPTION
- Adds a new check for algorithms whose turnover is too high
- Updates language for the warning emitted when asses are missing from the risk factor loadings