### PR TITLE
MAINT: Remove confusing gap in perf attribution summary table

### DIFF
--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -234,10 +234,10 @@ def show_perf_attrib_stats(returns, positions, factor_returns,
 
     print_table(perf_attrib_stats.loc[['Annualized Specific Return',
                                        'Annualized Common Return',
-                                       'Total Annualized Return']],
+                                       'Total Annualized Return',
+                                       'Specific Sharpe Ratio']],
                 name='Summary Statistics')
 
-    print_table(perf_attrib_stats[['Specific Sharpe Ratio']])
     print_table(risk_exposure_stats, name='Exposures Summary')
 
 


### PR DESCRIPTION
This gap doesn't render well on pandas/ipython versions that we're using on Q research. This PR removes the gap in the summary table, so that the sharpe ratio isn't free-floating.

Old UX:
<img width="351" alt="screen shot 2017-11-06 at 11 18 16 am" src="https://user-images.githubusercontent.com/3505048/32451777-bca81062-c2e5-11e7-93d9-ef19c3798d87.png">

New UX:
<img width="328" alt="screen shot 2017-11-06 at 11 27 06 am" src="https://user-images.githubusercontent.com/3505048/32451784-c1cc547c-c2e5-11e7-91db-ef4a7faca56f.png">
