### PR TITLE
MAINT: Reorder perf attrib risk exposures table

### DIFF
--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -205,10 +205,14 @@ def create_perf_attrib_stats(perf_attrib, risk_exposures):
                                     for c in risk_exposures.columns]
 
     risk_exposure_summary = pd.DataFrame(
-        data={'Annualized Return': annualized_returns_by_factor,
-              'Cumulative Return': cumulative_returns_by_factor,
-              'Average Risk Factor Exposure':
-              risk_exposures.mean(axis='rows')},
+        data=OrderedDict([
+            (
+                'Average Risk Factor Exposure',
+                risk_exposures.mean(axis='rows')
+            ),
+            ('Annualized Return', annualized_returns_by_factor),
+            ('Cumulative Return', cumulative_returns_by_factor),
+        ]),
         index=risk_exposures.columns,
     )
 

--- a/pyfolio/tests/test_perf_attrib.py
+++ b/pyfolio/tests/test_perf_attrib.py
@@ -168,8 +168,8 @@ class PerfAttribTestCase(unittest.TestCase):
         pd.util.testing.assert_frame_equal(
             exposures_summary,
             pd.DataFrame(0.0, index=['risk_factor1', 'risk_factor2'],
-                         columns=['Annualized Return',
-                                  'Average Risk Factor Exposure',
+                         columns=['Average Risk Factor Exposure',
+                                  'Annualized Return',
                                   'Cumulative Return'])
         )
 


### PR DESCRIPTION
So that the two 'returns' columns are next to each other, instead of being separated by a somewhat-less-related column. A screenshot of the new table, with toy risk model data:
![screen shot 2017-11-06 at 3 47 54 pm](https://user-images.githubusercontent.com/3505048/32465566-e662e0fe-c311-11e7-9702-e8efd4d3b89d.png)

@vikram-narayan does this look right?