### PR TITLE
perf attrib legend improvements

### DIFF
--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -419,7 +419,7 @@ def plot_factor_contribution_to_perf(perf_attrib_data, ax=None):
         ax.plot(factors_and_specific[col])
 
     ax.axhline(0, color='k')
-    set_legend_location(ax)
+    set_legend_location(ax, change_colors=True)
 
     ax.set_ylabel('Contribution to returns by factor')
     ax.set_title('Returns attribution')

--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -21,9 +21,9 @@ import pandas as pd
 import matplotlib.pyplot as plt
 
 from pyfolio.pos import get_percent_alloc
-from pyfolio.txn import get_turnover
-from pyfolio.utils import print_table, set_legend_location
 
+from pyfolio.txn import get_turnover
+from pyfolio.utils import print_table, configure_legend
 
 PERF_ATTRIB_TURNOVER_THRESHOLD = 0.25
 
@@ -352,7 +352,7 @@ def plot_returns(perf_attrib_data, cost=None, ax=None):
     ax.set_title('Time series of cumulative returns')
     ax.set_ylabel('Returns')
 
-    set_legend_location(ax)
+    configure_legend(ax)
 
     return ax
 
@@ -382,7 +382,7 @@ def plot_alpha_returns(alpha_returns, ax=None):
 
     avg = alpha_returns.mean()
     ax.axvline(avg, color='b', label='Mean = {: 0.5f}'.format(avg))
-    set_legend_location(ax)
+    configure_legend(ax)
 
     return ax
 
@@ -419,7 +419,7 @@ def plot_factor_contribution_to_perf(perf_attrib_data, ax=None):
         ax.plot(factors_and_specific[col])
 
     ax.axhline(0, color='k')
-    set_legend_location(ax, change_colors=True)
+    configure_legend(ax, change_colors=True)
 
     ax.set_ylabel('Contribution to returns by factor')
     ax.set_title('Returns attribution')
@@ -452,7 +452,7 @@ def plot_risk_exposures(exposures, ax=None):
     for col in exposures:
         ax.plot(exposures[col])
 
-    set_legend_location(ax)
+    configure_legend(ax)
     ax.set_ylabel('Factor exposures')
     ax.set_title('Risk factor exposures')
 

--- a/pyfolio/utils.py
+++ b/pyfolio/utils.py
@@ -15,8 +15,10 @@
 
 from __future__ import division
 
+from cycler import cycler
 import warnings
 
+from matplotlib.pyplot import cm
 import numpy as np
 import pandas as pd
 from IPython.display import display, HTML
@@ -51,18 +53,6 @@ DEPRECATION_WARNING = ("Data loaders have been moved to empyrical and will "
                        "be removed from pyfolio in a future release. Please "
                        "use e.g. empyrical.utils.get_symbol_rets() instead "
                        "of pyfolio.utils.get_symbol_rets()")
-
-# 31 visually distinct colors
-# http://phrogz.net/css/distinct-colors.html
-COLORS = [
-    '#f23d3d', '#828c23', '#698c83', '#594080', '#994d4d',
-    '#206380', '#dd39e6', '#cc9999', '#7c8060', '#66adcc',
-    '#6c7dd9', '#8a698c', '#7f6340', '#66cc7a', '#a3abd9',
-    '#d9c0a3', '#bfffcc', '#542699', '#b35986', '#d4e639',
-    '#b380ff', '#e0e6ac', '#a253a6', '#418020', '#ff409f',
-    '#ffa940', '#83ff40', '#3d58f2', '#e3ace6', '#d9a86c',
-    '#2db391'
-]
 
 
 def one_dec_places(x, pos):
@@ -626,13 +616,14 @@ def get_symbol_rets(symbol, start=None, end=None):
                                     end=end)
 
 
-def set_legend_location(ax, autofmt_xdate=True):
+def set_legend_location(ax, autofmt_xdate=True, change_colors=False):
     """
     Put legend in right of plot instead of overlapping with it.
     """
     chartBox = ax.get_position()
     ax.set_position([chartBox.x0, chartBox.y0,
                      chartBox.width * 0.75, chartBox.height])
+
 
     # make legend order match graph lines
     handles, labels = ax.get_legend_handles_labels()
@@ -643,6 +634,12 @@ def set_legend_location(ax, autofmt_xdate=True):
     handles_sorted = [h[0] for h in handles_and_labels_sorted]
     labels_sorted = [h[1] for h in handles_and_labels_sorted]
 
+    if change_colors:
+        for handle, color in zip(handles_sorted,
+                                 sample_colormap('tab20', len(handles))):
+
+            handle.set_color(color)
+
     ax.legend(handles=handles_sorted,
               labels=labels_sorted,
               frameon=True,
@@ -650,7 +647,17 @@ def set_legend_location(ax, autofmt_xdate=True):
               loc='upper left',
               bbox_to_anchor=(1.05, 1))
 
-    ax.set_prop_cycle('color', COLORS)
-
     if autofmt_xdate:
         ax.figure.autofmt_xdate()
+
+
+def sample_colormap(cmap_name, n_samples):
+    """
+    Sample a colormap from matplotlib
+    """
+    colors = []
+    colormap = cm.cmap_d[cmap_name]
+    for i in np.linspace(0, 1, n_samples):
+        colors.append(colormap(i))
+
+    return colors

--- a/pyfolio/utils.py
+++ b/pyfolio/utils.py
@@ -15,7 +15,6 @@
 
 from __future__ import division
 
-from cycler import cycler
 import warnings
 
 from matplotlib.pyplot import cm
@@ -624,11 +623,10 @@ def set_legend_location(ax, autofmt_xdate=True, change_colors=False):
     ax.set_position([chartBox.x0, chartBox.y0,
                      chartBox.width * 0.75, chartBox.height])
 
-
     # make legend order match graph lines
     handles, labels = ax.get_legend_handles_labels()
     handles_and_labels_sorted = sorted(zip(handles, labels),
-                                       key=lambda x : x[0].get_ydata()[-1],
+                                       key=lambda x: x[0].get_ydata()[-1],
                                        reverse=True)
 
     handles_sorted = [h[0] for h in handles_and_labels_sorted]

--- a/pyfolio/utils.py
+++ b/pyfolio/utils.py
@@ -634,7 +634,20 @@ def set_legend_location(ax, autofmt_xdate=True):
     ax.set_position([chartBox.x0, chartBox.y0,
                      chartBox.width * 0.75, chartBox.height])
 
-    ax.legend(frameon=True, framealpha=0.5, loc='upper left',
+    # make legend order match graph lines
+    handles, labels = ax.get_legend_handles_labels()
+    handles_and_labels_sorted = sorted(zip(handles, labels),
+                                       key=lambda x : x[0].get_ydata()[-1],
+                                       reverse=True)
+
+    handles_sorted = [h[0] for h in handles_and_labels_sorted]
+    labels_sorted = [h[1] for h in handles_and_labels_sorted]
+
+    ax.legend(handles=handles_sorted,
+              labels=labels_sorted,
+              frameon=True,
+              framealpha=0.5,
+              loc='upper left',
               bbox_to_anchor=(1.05, 1))
 
     ax.set_prop_cycle('color', COLORS)

--- a/pyfolio/utils.py
+++ b/pyfolio/utils.py
@@ -53,6 +53,8 @@ DEPRECATION_WARNING = ("Data loaders have been moved to empyrical and will "
                        "use e.g. empyrical.utils.get_symbol_rets() instead "
                        "of pyfolio.utils.get_symbol_rets()")
 
+COLORMAP = 'tab20'
+
 
 def one_dec_places(x, pos):
     """
@@ -615,9 +617,12 @@ def get_symbol_rets(symbol, start=None, end=None):
                                     end=end)
 
 
-def set_legend_location(ax, autofmt_xdate=True, change_colors=False):
+def configure_legend(ax, autofmt_xdate=True, change_colors=False):
     """
-    Put legend in right of plot instead of overlapping with it.
+    Format legend for perf attribution plots:
+    - put legend to the right of plot instead of overlapping with it
+    - make legend order match up with graph lines
+    - set colors according to colormap
     """
     chartBox = ax.get_position()
     ax.set_position([chartBox.x0, chartBox.y0,
@@ -634,7 +639,7 @@ def set_legend_location(ax, autofmt_xdate=True, change_colors=False):
 
     if change_colors:
         for handle, color in zip(handles_sorted,
-                                 sample_colormap('tab20', len(handles))):
+                                 sample_colormap(COLORMAP, len(handles))):
 
             handle.set_color(color)
 


### PR DESCRIPTION
- make the end of each line match up with the ordering of the legend
![returns_plot](https://user-images.githubusercontent.com/8713773/32507257-041b1f00-c3b5-11e7-8e70-817dcc0ed495.png)

- use `set_color` with colormaps rather than `set_prop_cycle`. Currently using the tab20 colormap: https://matplotlib.org/examples/color/colormaps_reference.html
![factor_contribution_plot](https://user-images.githubusercontent.com/8713773/32507423-5ce01ca8-c3b5-11e7-8aed-6f479975cf74.png)
