### PR TITLE
MAINT: truncate warnings

### DIFF
--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -138,24 +138,32 @@ def perf_attrib(returns,
     if len(missing_stocks) > 0:
 
         if len(missing_stocks) > 5:
-            missing_stocks_displayed = list(missing_stocks[:5])
+            missing_stocks_displayed = (
+                " {} assets were missing factor loadings, including: {}"
+            ).format(len(missing_stocks),
+                     list(missing_stocks[:5]))
+            avg_allocation_msg = "selected missing assets"
+
         else:
-            missing_stocks_displayed = list(missing_stocks)
+            missing_stocks_displayed = (
+                "The following assets were missing factor loadings: {}."
+            ).format(list(missing_stocks))
+            avg_allocation_msg = "missing assets"
 
         missing_stocks_warning_msg = (
             "Could not determine risk exposures for some of this algorithm's "
             "positions. Returns from the missing assets will not be properly "
             "accounted for in performance attribution.\n"
             "\n"
-            "The following assets were missing factor loadings: {}. "
+            "{}. "
             "Ignoring for exposure calculation and performance attribution. "
-            "Ratio of assets missing: {}. Average allocation of missing "
-            "assets:\n"
+            "Ratio of assets missing: {}. Average allocation of {}:\n"
             "\n"
             "{}.\n"
         ).format(
             missing_stocks_displayed,
             missing_ratio,
+            avg_allocation_msg,
             positions[missing_stocks[:5]].mean(),
         )
 
@@ -171,16 +179,21 @@ def perf_attrib(returns,
     if len(missing_factor_loadings_index) > 0:
 
         if len(missing_factor_loadings_index) > 5:
-            missing_dates_displayed = "{}..{}".format(
+            missing_dates_displayed = (
+                "(first missing is {}, last missing is {})"
+            ).format(
                 missing_factor_loadings_index[0],
                 missing_factor_loadings_index[-1]
             )
         else:
             missing_dates_displayed = list(missing_factor_loadings_index)
 
-        warnings.warn("Could not find factor loadings for the dates: {}. "
-                      "Truncating date range for performance attribution. "
-                      .format(missing_dates_displayed))
+        warning_msg = (
+            "Could not find factor loadings for {} dates: {}. "
+            "Truncating date range for performance attribution. "
+        ).format(len(missing_factor_loadings_index), missing_dates_displayed)
+
+        warnings.warn(warning_msg)
 
         positions = positions.drop(missing_factor_loadings_index,
                                    errors='ignore')

--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -137,6 +137,11 @@ def perf_attrib(returns,
 
     if len(missing_stocks) > 0:
 
+        if len(missing_stocks) > 5:
+            missing_stocks_displayed = list(missing_stocks[:5])
+        else:
+            missing_stocks_displayed = list(missing_stocks)
+
         missing_stocks_warning_msg = (
             "Could not determine risk exposures for some of this algorithm's "
             "positions. Returns from the missing assets will not be properly "
@@ -149,9 +154,9 @@ def perf_attrib(returns,
             "\n"
             "{}.\n"
         ).format(
-            list(missing_stocks),
+            missing_stocks_displayed,
             missing_ratio,
-            positions[missing_stocks].mean(),
+            positions[missing_stocks[:5]].mean(),
         )
 
         warnings.warn(missing_stocks_warning_msg)
@@ -165,9 +170,17 @@ def perf_attrib(returns,
 
     if len(missing_factor_loadings_index) > 0:
 
+        if len(missing_factor_loadings_index) > 5:
+            missing_dates_displayed = "{}..{}".format(
+                missing_factor_loadings_index[0],
+                missing_factor_loadings_index[-1]
+            )
+        else:
+            missing_dates_displayed = list(missing_factor_loadings_index)
+
         warnings.warn("Could not find factor loadings for the dates: {}. "
                       "Truncating date range for performance attribution. "
-                      .format(list(missing_factor_loadings_index)))
+                      .format(missing_dates_displayed))
 
         positions = positions.drop(missing_factor_loadings_index,
                                    errors='ignore')

--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -138,10 +138,12 @@ def perf_attrib(returns,
     if len(missing_stocks) > 0:
 
         if len(missing_stocks) > 5:
+
             missing_stocks_displayed = (
-                " {} assets were missing factor loadings, including: {}"
+                " {} assets were missing factor loadings, including: {}..{}"
             ).format(len(missing_stocks),
-                     list(missing_stocks[:5]))
+                     ', '.join(missing_stocks[:5].map(str)),
+                     missing_stocks[-1])
             avg_allocation_msg = "selected missing assets"
 
         else:
@@ -164,7 +166,7 @@ def perf_attrib(returns,
             missing_stocks_displayed,
             missing_ratio,
             avg_allocation_msg,
-            positions[missing_stocks[:5]].mean(),
+            positions[missing_stocks[:5].union(missing_stocks[[-1]])].mean(),
         )
 
         warnings.warn(missing_stocks_warning_msg)

--- a/pyfolio/tests/test_perf_attrib.py
+++ b/pyfolio/tests/test_perf_attrib.py
@@ -339,7 +339,8 @@ class PerfAttribTestCase(unittest.TestCase):
 
             self.assertEqual(len(w), 2)
             self.assertIn("Could not find factor loadings for "
-                          "the dates", str(w[-1].message))
+                          "{} dates".format(len(missing_dates)),
+                          str(w[-1].message))
 
             for date in missing_dates:
                 self.assertNotIn(date, exposures.index)
@@ -355,7 +356,8 @@ class PerfAttribTestCase(unittest.TestCase):
 
             self.assertEqual(len(w), 3)
             self.assertIn("Could not find factor loadings for "
-                          "the dates", str(w[-1].message))
+                          "{} dates".format(len(missing_dates)),
+                          str(w[-1].message))
 
             for date in missing_dates:
                 self.assertNotIn(date, exposures.index)
@@ -377,7 +379,8 @@ class PerfAttribTestCase(unittest.TestCase):
             self.assertIn("Ratio of assets missing: 0.333", str(w[-2].message))
 
             self.assertIn("Could not find factor loadings for "
-                          "the dates", str(w[-1].message))
+                          "{} dates".format(len(missing_dates)),
+                          str(w[-1].message))
             for date in missing_dates:
                 self.assertNotIn(date, exposures.index)
                 self.assertNotIn(date, perf_attrib_data.index)


### PR DESCRIPTION
truncate missing stock/date warnings if there are more than five missing stocks/dates

missing stock warning:
![truncated warning missing stocks](https://user-images.githubusercontent.com/8713773/32506737-5e299fa0-c3b3-11e7-9e51-ce0ad6d59223.png)

missing date warning:
![truncated warning missing dates](https://user-images.githubusercontent.com/8713773/32506745-630ca8fa-c3b3-11e7-9918-11edcb889e62.png)
