### PR TITLE
BUG: drop alpha when plotting rolling fama french

### DIFF
--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -189,6 +189,7 @@ def plot_rolling_fama_french(returns,
         factor_returns=factor_returns,
         rolling_window=rolling_window)
 
+    rolling_beta = rolling_beta[['SMB', 'HML', 'Mom']]
     rolling_beta.plot(alpha=0.7, ax=ax, **kwargs)
 
     ax.axhline(0.0, color='black')

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ install_reqs = [
     'scikit-learn>=0.16.1',
     'seaborn>=0.7.1',
     'pandas-datareader>=0.2',
-    'empyrical>=0.3.2'
+    'empyrical>=0.3.3'
 ]
 
 test_reqs = ['nose>=1.3.7', 'nose-parameterized>=0.5.0', 'runipy>=0.1.3']


### PR DESCRIPTION
When alpha is in the call to `rolling_beta.plot`, it doesn't show up, which messes up the ordering of the legend.



