### PR TITLE
perf attrib plot updates

### DIFF
--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -473,14 +473,14 @@ def plot_factor_contribution_to_perf(perf_attrib_data, ax=None,
     if ax is None:
         ax = plt.gca()
 
-    factors_and_specific = perf_attrib_data.drop(
+    factors_to_plot = perf_attrib_data.drop(
         ['total_returns', 'common_returns'], axis='columns', errors='ignore'
     )
 
-    factors_and_specific_cumulative = ep.cum_returns(factors_and_specific)
+    factors_cumulative = ep.cum_returns(factors_to_plot)
 
-    for col in factors_and_specific_cumulative:
-        ax.plot(factors_and_specific_cumulative[col])
+    for col in factors_cumulative:
+        ax.plot(factors_cumulative[col])
 
     ax.axhline(0, color='k')
     configure_legend(ax, change_colors=True)

--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -444,8 +444,11 @@ def plot_alpha_returns(alpha_returns, ax=None):
     return ax
 
 
-def plot_factor_contribution_to_perf(perf_attrib_data, ax=None,
-                                     title='Cumulative returns attribution'):
+def plot_factor_contribution_to_perf(
+        perf_attrib_data,
+        ax=None,
+        title='Cumulative common returns attribution'
+):
     """
     Plot each factor's contribution to performance.
 

--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -447,7 +447,7 @@ def plot_alpha_returns(alpha_returns, ax=None):
 def plot_factor_contribution_to_perf(
         perf_attrib_data,
         ax=None,
-        title='Cumulative common returns attribution'
+        title='Cumulative common returns attribution',
 ):
     """
     Plot each factor's contribution to performance.

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -1554,8 +1554,9 @@ def create_perf_attrib_tear_sheet(returns,
             perf_attrib.plot_factor_contribution_to_perf(
                 perf_attrib_data[columns_to_select],
                 ax=plt.subplot(gs[current_section]),
-                title='Cumulative common {} returns attribution'
-                .format(factor_type)
+                title=(
+                    'Cumulative common {} returns attribution'
+                ).format(factor_type)
             )
             current_section += 1
 

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -1548,7 +1548,7 @@ def create_perf_attrib_tear_sheet(returns,
         for factor_type, partitions in factor_partitions.iteritems():
 
             columns_to_select = perf_attrib_data.columns.intersection(
-                partitions + ['specific_returns']
+                partitions
             )
 
             perf_attrib.plot_factor_contribution_to_perf(

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -1554,7 +1554,8 @@ def create_perf_attrib_tear_sheet(returns,
             perf_attrib.plot_factor_contribution_to_perf(
                 perf_attrib_data[columns_to_select],
                 ax=plt.subplot(gs[current_section]),
-                title='Cumulative {} returns attribution'.format(factor_type)
+                title='Cumulative common {} returns attribution'
+                .format(factor_type)
             )
             current_section += 1
 

--- a/pyfolio/tests/test_perf_attrib.py
+++ b/pyfolio/tests/test_perf_attrib.py
@@ -28,7 +28,7 @@ def generate_toy_risk_model_output(start_date='2017-01-01', periods=10,
     dts = pd.date_range(start_date, periods=periods)
     np.random.seed(123)
     tickers = ['AAPL', 'TLT', 'XOM']
-    styles = ['factor{}'.format(i) for i in xrange(num_styles)]
+    styles = ['factor{}'.format(i) for i in range(num_styles)]
 
     returns = pd.Series(index=dts,
                         data=np.random.randn(periods)) / 100


### PR DESCRIPTION
- don't plot `specific_returns` in style/sector breakout plots
- add `common` to style/sector breakout plots