### PR TITLE
add header to indicate perf attrib in tearsheet

### DIFF
--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -1541,7 +1541,7 @@ def create_perf_attrib_tear_sheet(returns,
 
     # one section for the returns plot, and for each factor grouping
     # one section for factor returns, and one for risk exposures
-    vertical_sections = 1 + 2 * len(factor_partitions)
+    vertical_sections = 1 + 2 * max(len(factor_partitions), 1)
     current_section = 0
 
     fig = plt.figure(figsize=[14, vertical_sections * 6])

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -18,6 +18,7 @@ import warnings
 from time import time
 
 import empyrical as ep
+from IPython.display import display, Markdown
 import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
 import numpy as np
@@ -1532,6 +1533,8 @@ def create_perf_attrib_tear_sheet(returns,
         pos_in_dollars=pos_in_dollars
     )
 
+    display(Markdown("## Performance Relative to Common Risk Factors"))
+
     # aggregate perf attrib stats and show summary table
     perf_attrib.show_perf_attrib_stats(returns, positions, factor_returns,
                                        factor_loadings, transactions)
@@ -1542,6 +1545,7 @@ def create_perf_attrib_tear_sheet(returns,
     current_section = 0
 
     fig = plt.figure(figsize=[14, vertical_sections * 6])
+
     gs = gridspec.GridSpec(vertical_sections, 1,
                            wspace=0.5, hspace=0.5)
 


### PR DESCRIPTION
- add header saying `Performance Relative to Common Risk Factors`. Screenshot:
![screen shot 2017-11-27 at 3 44 23 pm](https://user-images.githubusercontent.com/8713773/33288665-0f26508c-d38b-11e7-9d22-2e65f056cd30.png)

- make sure GridSpec includes at least one section for attributed returns and factor exposures