### PR TITLE
BUG: plot cumulative costs in plot_returns

### DIFF
--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -360,6 +360,7 @@ def plot_returns(perf_attrib_data, cost=None, ax=None):
     returns = perf_attrib_data['total_returns']
     total_returns_label = 'Total returns'
 
+    cumulative_returns_less_costs = returns
     if cost is not None:
         cumulative_returns_less_costs = _cumulative_returns_less_costs(
             returns,

--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -360,12 +360,12 @@ def plot_returns(perf_attrib_data, cost=None, ax=None):
     returns = perf_attrib_data['total_returns']
     total_returns_label = 'Total returns'
 
-    cumulative_returns_less_costs = returns
+
+    cumulative_returns_less_costs = _cumulative_returns_less_costs(
+        returns,
+        cost
+    )
     if cost is not None:
-        cumulative_returns_less_costs = _cumulative_returns_less_costs(
-            returns,
-            cost
-        )
         total_returns_label += ' (adjusted)'
 
     specific_returns = perf_attrib_data['specific_returns']
@@ -653,4 +653,6 @@ def _cumulative_returns_less_costs(returns, costs):
     """
     Compute cumulative returns, less costs.
     """
+    if costs is None:
+        costs = 0
     return ep.cum_returns(returns - costs)

--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -370,7 +370,8 @@ def plot_returns(perf_attrib_data, cost=None, ax=None):
     specific_returns = perf_attrib_data['specific_returns']
     common_returns = perf_attrib_data['common_returns']
 
-    ax.plot(ep.cum_returns(returns), color='b', label=total_returns_label)
+    ax.plot(cumulative_returns_less_costs, color='b',
+            label=total_returns_label)
     ax.plot(ep.cum_returns(specific_returns), color='g',
             label='Cumulative specific returns')
     ax.plot(ep.cum_returns(common_returns), color='r',

--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -360,7 +360,6 @@ def plot_returns(perf_attrib_data, cost=None, ax=None):
     returns = perf_attrib_data['total_returns']
     total_returns_label = 'Total returns'
 
-
     cumulative_returns_less_costs = _cumulative_returns_less_costs(
         returns,
         cost
@@ -654,5 +653,5 @@ def _cumulative_returns_less_costs(returns, costs):
     Compute cumulative returns, less costs.
     """
     if costs is None:
-        costs = 0
+        return ep.cum_returns(returns)
     return ep.cum_returns(returns - costs)

--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -361,8 +361,10 @@ def plot_returns(perf_attrib_data, cost=None, ax=None):
     total_returns_label = 'Total returns'
 
     if cost is not None:
-        cost = ep.cum_returns(cost)
-        returns = returns - cost
+        cumulative_returns_less_costs = _cumulative_returns_less_costs(
+            returns,
+            cost
+        )
         total_returns_label += ' (adjusted)'
 
     specific_returns = perf_attrib_data['specific_returns']
@@ -375,7 +377,8 @@ def plot_returns(perf_attrib_data, cost=None, ax=None):
             label='Cumulative common returns')
 
     if cost is not None:
-        ax.plot(-cost, color='k', label='Cumulative cost spent')
+        ax.plot(-ep.cum_returns(cost), color='k',
+                label='Cumulative cost spent')
 
     ax.set_title('Time series of cumulative returns')
     ax.set_ylabel('Returns')
@@ -642,3 +645,10 @@ def _stack_positions(positions, pos_in_dollars=True):
     positions.index = positions.index.set_names(['dt', 'ticker'])
 
     return positions
+
+
+def _cumulative_returns_less_costs(returns, costs):
+    """
+    Compute cumulative returns, less costs.
+    """
+    return ep.cum_returns(returns - costs)

--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -361,6 +361,7 @@ def plot_returns(perf_attrib_data, cost=None, ax=None):
     total_returns_label = 'Total returns'
 
     if cost is not None:
+        cost = ep.cum_returns(cost)
         returns = returns - cost
         total_returns_label += ' (adjusted)'
 
@@ -374,7 +375,7 @@ def plot_returns(perf_attrib_data, cost=None, ax=None):
             label='Cumulative common returns')
 
     if cost is not None:
-        ax.plot(cost, color='p', label='Cost')
+        ax.plot(-cost, color='k', label='Cumulative cost spent')
 
     ax.set_title('Time series of cumulative returns')
     ax.set_ylabel('Returns')

--- a/pyfolio/tests/test_perf_attrib.py
+++ b/pyfolio/tests/test_perf_attrib.py
@@ -4,7 +4,11 @@ import unittest
 import warnings
 
 import empyrical as ep
-from pyfolio.perf_attrib import perf_attrib, create_perf_attrib_stats
+from pyfolio.perf_attrib import (
+    perf_attrib,
+    create_perf_attrib_stats,
+    _cumulative_returns_less_costs
+)
 
 
 def generate_toy_risk_model_output(start_date='2017-01-01', periods=10,
@@ -446,4 +450,19 @@ class PerfAttribTestCase(unittest.TestCase):
         self.assertIn(
             "This algorithm has relatively high turnover of its positions.",
             str(w[-1].message),
+        )
+
+    def test_cumulative_returns_less_costs(self):
+
+        returns = generate_toy_risk_model_output()[0]
+        cost = pd.Series([0.001] * len(returns), index=returns.index)
+
+        pd.util.testing.assert_series_equal(
+            ep.cum_returns(returns),
+            _cumulative_returns_less_costs(returns, None)
+        )
+
+        pd.util.testing.assert_series_equal(
+            ep.cum_returns(returns - cost),
+            _cumulative_returns_less_costs(returns, cost)
         )

--- a/pyfolio/tests/test_perf_attrib.py
+++ b/pyfolio/tests/test_perf_attrib.py
@@ -454,15 +454,22 @@ class PerfAttribTestCase(unittest.TestCase):
 
     def test_cumulative_returns_less_costs(self):
 
-        returns = generate_toy_risk_model_output()[0]
+        returns = pd.Series(
+            [0.1] * 3,
+            index=pd.date_range('2017-01-01', periods=3)
+        )
         cost = pd.Series([0.001] * len(returns), index=returns.index)
 
+        expected_returns = pd.Series([0.1, 0.21, 0.331],
+                                     index=returns.index)
         pd.util.testing.assert_series_equal(
-            ep.cum_returns(returns),
+            expected_returns,
             _cumulative_returns_less_costs(returns, None)
         )
 
+        expected_returns = pd.Series([0.099000, 0.207801, 0.327373],
+                                     index=returns.index)
         pd.util.testing.assert_series_equal(
-            ep.cum_returns(returns - cost),
+            expected_returns,
             _cumulative_returns_less_costs(returns, cost)
         )


### PR DESCRIPTION
- when plotting cumulative returns, cost should be cumulative as well.
- plot negative cost