### PR TITLE
Correct plotting.plot_rolling_fama_french() legend

### DIFF
--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -194,7 +194,7 @@ def plot_rolling_fama_french(returns,
 
     ax.axhline(0.0, color='black')
     ax.legend(['Small cap (SMB)',
-               'High growth (HML)',
+               'Value (HML)',
                'Momentum (UMD)'],
               loc=legend_loc, frameon=True, framealpha=0.5)
 


### PR DESCRIPTION
In reference to issue #499, change the legend in the `plotting.plot_rolling_fama_french()` function to reflect HML factor being associated with Value.