### PR TITLE
fix SystemError: <class 'str'> returned a result with an error set

### DIFF
--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -896,10 +896,10 @@ def get_max_drawdown_underwater(underwater):
 
     valley = np.argmin(underwater)  # end of the period
     # Find first 0
-    peak = underwater[:valley][underwater[:valley] == 0].index[-1]
+    peak = underwater[:valley].loc[underwater[:valley] == 0].index[-1]
     # Find last 0
     try:
-        recovery = underwater[valley:][underwater[valley:] == 0].index[0]
+        recovery = underwater[valley:].loc[underwater[valley:] == 0].index[0]
     except IndexError:
         recovery = np.nan  # drawdown not recovered
     return peak, valley, recovery


### PR DESCRIPTION
This happens on my particular platform.
python 3.6.3 pandas 0.18.1

SystemError: <class 'str'> returned a result with an error set