### PR TITLE
Added LICENSE to the manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include versioneer.py
 include pyfolio/_version.py
+include LICENSE


### PR DESCRIPTION
We need the license to be included in the code; this is also important for deployment on conda-forge.