### PR TITLE
fixed a bug in create_perf_attrib_tear_sheet

### DIFF
--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -1553,7 +1553,7 @@ def create_perf_attrib_tear_sheet(returns,
 
     # aggregate perf attrib stats and show summary table
     perf_attrib.show_perf_attrib_stats(returns, positions, factor_returns,
-                                       factor_loadings, transactions)
+                                       factor_loadings, transactions, pos_in_dollars)
 
     # one section for the returns plot, and for each factor grouping
     # one section for factor returns, and one for risk exposures

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -1554,7 +1554,7 @@ def create_perf_attrib_tear_sheet(returns,
     # aggregate perf attrib stats and show summary table
     perf_attrib.show_perf_attrib_stats(returns, positions, factor_returns,
                                        factor_loadings, transactions,
-                                       pos_in_dollars=pos_in_dollars)
+                                       pos_in_dollars)
 
     # one section for the returns plot, and for each factor grouping
     # one section for factor returns, and one for risk exposures

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -1553,7 +1553,8 @@ def create_perf_attrib_tear_sheet(returns,
 
     # aggregate perf attrib stats and show summary table
     perf_attrib.show_perf_attrib_stats(returns, positions, factor_returns,
-                                       factor_loadings, transactions, pos_in_dollars)
+                                       factor_loadings, transactions,
+                                       pos_in_dollars=pos_in_dollars)
 
     # one section for the returns plot, and for each factor grouping
     # one section for factor returns, and one for risk exposures


### PR DESCRIPTION
In function `create_perf_attrib_tear_sheet`, it calls `perf_attrib.show_perf_attrib_stats` to show the stats without passing the input `pos_in_dollars`. It would cause problem when positions are in percentage. Fixed it by adding `pos_in_dollars` as input. 