### PR TITLE
MAINT: factor_loadings index names should match positions

### DIFF
--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -612,6 +612,8 @@ def _align_and_warn(returns,
             )
             warnings.warn(warning_msg)
 
+    factor_loadings.index = factor_loadings.index.set_names(['dt', 'ticker'])
+
     return (returns, positions, factor_returns, factor_loadings)
 
 

--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -612,6 +612,7 @@ def _align_and_warn(returns,
             )
             warnings.warn(warning_msg)
 
+    factor_loadings = factor_loadings.copy()
     factor_loadings.index = factor_loadings.index.set_names(['dt', 'ticker'])
 
     return (returns, positions, factor_returns, factor_loadings)

--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -608,8 +608,20 @@ def _align_and_warn(returns,
             )
             warnings.warn(warning_msg)
 
-    factor_loadings = factor_loadings.copy(deep=False)
-    factor_loadings.index = factor_loadings.index.set_names(['dt', 'ticker'])
+    # remove any extra data in factor loadings
+    extra_factor_loadings_dates = factor_loadings.index.levels[0].difference(
+        positions.index
+    )
+    if len(extra_factor_loadings_dates):
+        factor_loadings = factor_loadings.drop(extra_factor_loadings_dates)
+
+    extra_factor_loadings_stocks = factor_loadings.index.levels[1].difference(
+        positions.columns
+    )
+    if len(extra_factor_loadings_stocks):
+        factor_loadings = factor_loadings.drop(
+            extra_factor_loadings_stocks, level=1
+        )
 
     return (returns, positions, factor_returns, factor_loadings)
 

--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -567,10 +567,6 @@ def _align_and_warn(returns,
         factor_loadings.index.get_level_values(0).unique()
     )
 
-    missing_factor_loadings_index = positions.index.difference(
-        factor_loadings.index.get_level_values(0).unique()
-    )
-
     if len(missing_factor_loadings_index) > 0:
 
         if len(missing_factor_loadings_index) > 5:
@@ -612,7 +608,7 @@ def _align_and_warn(returns,
             )
             warnings.warn(warning_msg)
 
-    factor_loadings = factor_loadings.copy()
+    factor_loadings = factor_loadings.copy(deep=False)
     factor_loadings.index = factor_loadings.index.set_names(['dt', 'ticker'])
 
     return (returns, positions, factor_returns, factor_loadings)

--- a/pyfolio/tests/test_perf_attrib.py
+++ b/pyfolio/tests/test_perf_attrib.py
@@ -519,8 +519,10 @@ class PerfAttribTestCase(unittest.TestCase):
         ):
             factor_loadings.multiply(positions, axis='rows')
 
+        expected_index = dts.set_names(['dates'])
+
         expected_perf_attrib_output = pd.DataFrame(
-            index=dts,
+            index=expected_index,
             columns=['risk_factor1', 'risk_factor2', 'common_returns',
                      'specific_returns', 'total_returns'],
             data={'risk_factor1': [0.025, 0.025],
@@ -531,7 +533,7 @@ class PerfAttribTestCase(unittest.TestCase):
         )
 
         expected_exposures_portfolio = pd.DataFrame(
-            index=dts,
+            index=expected_index,
             columns=['risk_factor1', 'risk_factor2'],
             data=0.25
         )

--- a/pyfolio/tests/test_perf_attrib.py
+++ b/pyfolio/tests/test_perf_attrib.py
@@ -483,13 +483,12 @@ class PerfAttribTestCase(unittest.TestCase):
         tickers = ['stock1', 'stock2']
         styles = ['risk_factor1', 'risk_factor2']
 
-        returns = pd.Series(data=[0.1, 0.1], index=dts)
+        returns = pd.Series(data=0.1, index=dts)
 
         factor_returns = pd.DataFrame(
             columns=styles,
             index=dts,
-            data={'risk_factor1': [.1, .1],
-                  'risk_factor2': [.1, .1]}
+            data=0.1
         )
 
         # since positions has no stock2 column, it will not multiply with
@@ -506,8 +505,7 @@ class PerfAttribTestCase(unittest.TestCase):
         factor_loadings = pd.DataFrame(
             columns=styles,
             index=index,
-            data={'risk_factor1': [0.25, 0.25, 0.25, 0.25],
-                  'risk_factor2': [0.25, 0.25, 0.25, 0.25]}
+            data=0.25
         )
         factor_loadings.index =\
             factor_loadings.index.set_names(['dates', 'asset'])
@@ -535,8 +533,7 @@ class PerfAttribTestCase(unittest.TestCase):
         expected_exposures_portfolio = pd.DataFrame(
             index=dts,
             columns=['risk_factor1', 'risk_factor2'],
-            data={'risk_factor1': [0.25, 0.25],
-                  'risk_factor2': [0.25, 0.25]}
+            data=0.25
         )
 
         exposures_portfolio, perf_attrib_output = perf_attrib(returns,

--- a/pyfolio/tests/test_perf_attrib.py
+++ b/pyfolio/tests/test_perf_attrib.py
@@ -544,6 +544,9 @@ class PerfAttribTestCase(unittest.TestCase):
                                                               factor_returns,
                                                               factor_loadings)
 
+        # make sure perf_attrib doesn't change the factor_loadings input
+        self.assertEqual(factor_loadings.index.names, ['dates', 'asset'])
+
         pd.util.testing.assert_frame_equal(expected_perf_attrib_output,
                                            perf_attrib_output)
 


### PR DESCRIPTION
Make the index names of `factor_loadings` must match `positions` when computing exposures