### PR TITLE
MAINT: add NOT_PASSED_SENTINEL

### DIFF
--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -923,7 +923,10 @@ def create_round_trip_tear_sheet(returns, positions, transactions,
 
 @plotting.customize
 def create_interesting_times_tear_sheet(
-        returns, benchmark_rets=utils.NOT_PASSED_SENTINEL, legend_loc='best', return_fig=False):
+        returns,
+        benchmark_rets=utils.NOT_PASSED_SENTINEL,
+        legend_loc='best',
+        return_fig=False):
     """
     Generate a number of returns plots around interesting points in time,
     like the flash crash and 9/11.

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -527,17 +527,20 @@ def create_returns_tear_sheet(returns, positions=None,
 
     plotting.show_worst_drawdown_periods(returns)
 
-    vertical_sections = 11
+    always_sections = 11
+    live_start_date_sections = 1 if (live_start_date is not None) else 0
+    benchmark_sections = 1 if (benchmark_rets is not None) else 0
+    bootstrap_sections = 1 if bootstrap else 0
+
+    vertical_sections = sum([
+        always_sections,
+        live_start_date_sections,
+        benchmark_sections,
+        bootstrap_sections
+    ])
 
     if live_start_date is not None:
-        vertical_sections += 1
         live_start_date = ep.utils.get_utc_timestamp(live_start_date)
-
-    if benchmark_rets is not None:
-        vertical_sections += 1
-
-    if bootstrap:
-        vertical_sections += 1
 
     fig = plt.figure(figsize=(14, vertical_sections * 6))
     gs = gridspec.GridSpec(vertical_sections, 3, wspace=0.5, hspace=0.5)

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -514,7 +514,7 @@ def create_returns_tear_sheet(returns, positions=None,
         warnings.warn(BENCHMARK_RETS_WARNING)
         benchmark_rets = None
 
-    if benchmark_rets not in (None, utils.NOT_PASSED_SENTINEL):
+    if benchmark_rets is not None:
         returns = utils.clip_returns_to_benchmark(returns, benchmark_rets)
 
     plotting.show_perf_stats(returns, benchmark_rets,
@@ -533,7 +533,7 @@ def create_returns_tear_sheet(returns, positions=None,
         vertical_sections += 1
         live_start_date = ep.utils.get_utc_timestamp(live_start_date)
 
-    if benchmark_rets not in (None, utils.NOT_PASSED_SENTINEL):
+    if benchmark_rets is not None:
         vertical_sections += 1
 
     if bootstrap:
@@ -553,7 +553,7 @@ def create_returns_tear_sheet(returns, positions=None,
     ax_returns = plt.subplot(gs[i, :],
                              sharex=ax_rolling_returns)
     i += 1
-    if benchmark_rets not in (None, utils.NOT_PASSED_SENTINEL):
+    if benchmark_rets is not None:
         ax_rolling_beta = plt.subplot(gs[i, :], sharex=ax_rolling_returns)
         i += 1
     ax_rolling_volatility = plt.subplot(gs[i, :], sharex=ax_rolling_returns)
@@ -609,7 +609,7 @@ def create_returns_tear_sheet(returns, positions=None,
     ax_returns.set_title(
         'Returns')
 
-    if benchmark_rets not in (None, utils.NOT_PASSED_SENTINEL):
+    if benchmark_rets is not None:
         plotting.plot_rolling_beta(
             returns, benchmark_rets, ax=ax_rolling_beta)
 
@@ -636,7 +636,7 @@ def create_returns_tear_sheet(returns, positions=None,
         ax=ax_return_quantiles)
 
     if ((bootstrap is not None)
-            and (benchmark_rets not in (None, utils.NOT_PASSED_SENTINEL))):
+            and (benchmark_rets is not None)):
         ax_bootstrap = plt.subplot(gs[i, :])
         plotting.plot_perf_stats(returns, benchmark_rets,
                                  ax=ax_bootstrap)
@@ -977,7 +977,7 @@ def create_interesting_times_tear_sheet(
                       name='Stress Events',
                       float_format='{0:.2f}%'.format)
 
-    if benchmark_rets not in (None, utils.NOT_PASSED_SENTINEL):
+    if benchmark_rets is not None:
         returns = utils.clip_returns_to_benchmark(returns, benchmark_rets)
 
     bmark_interesting = timeseries.extract_interesting_date_ranges(
@@ -996,7 +996,7 @@ def create_interesting_times_tear_sheet(
         ep.cum_returns(rets_period).plot(
             ax=ax, color='forestgreen', label='algo', alpha=0.7, lw=2)
 
-        if benchmark_rets not in (None, utils.NOT_PASSED_SENTINEL):
+        if benchmark_rets is not None:
             ep.cum_returns(bmark_interesting[name]).plot(
                 ax=ax, color='gray', label='benchmark', alpha=0.6)
             ax.legend(['Algo',
@@ -1157,6 +1157,10 @@ def create_bayesian_tear_sheet(returns,
     progressbar : boolean, optional
         If True, show a progress bar
     """
+    if (isinstance(benchmark_rets, str)
+            and benchmark_rets == utils.NOT_PASSED_SENTINEL):
+        warnings.warn(BENCHMARK_RETS_WARNING)
+        benchmark_rets = None
 
     if not have_bayesian:
         raise NotImplementedError(
@@ -1259,7 +1263,7 @@ def create_bayesian_tear_sheet(returns,
     previous_time = timer("plotting Bayesian VaRs estimate", previous_time)
 
     # Run alpha beta model
-    if benchmark_rets not in (None, utils.NOT_PASSED_SENTINEL):
+    if benchmark_rets is not None:
         print("\nRunning alpha beta model")
         benchmark_rets = benchmark_rets.loc[df_train.index]
         trace_alpha_beta = bayesian.run_model('alpha_beta', df_train,

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -555,10 +555,10 @@ def create_returns_tear_sheet(returns, positions=None,
     i += 1
     ax_returns = plt.subplot(gs[i, :],
                              sharex=ax_rolling_returns)
-    i += 1
     if benchmark_rets is not None:
-        ax_rolling_beta = plt.subplot(gs[i, :], sharex=ax_rolling_returns)
         i += 1
+        ax_rolling_beta = plt.subplot(gs[i, :], sharex=ax_rolling_returns)
+    i += 1
     ax_rolling_volatility = plt.subplot(gs[i, :], sharex=ax_rolling_returns)
     i += 1
     ax_rolling_sharpe = plt.subplot(gs[i, :], sharex=ax_rolling_returns)

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -197,6 +197,7 @@ def create_full_tear_sheet(returns,
     """
     if benchmark_rets == utils.NOT_PASSED_SENTINEL:
         warnings.warn(BENCHMARK_RETS_WARNING)
+        benchmark_rets = None
 
     if (unadjusted_returns is None) and (slippage is not None) and\
        (transactions is not None):
@@ -346,6 +347,7 @@ def create_simple_tear_sheet(returns,
 
     if benchmark_rets == utils.NOT_PASSED_SENTINEL:
         warnings.warn(BENCHMARK_RETS_WARNING)
+        benchmark_rets = None
 
     if (slippage is not None) and (transactions is not None):
         returns = txn.adjust_returns_for_slippage(returns, positions,
@@ -507,6 +509,7 @@ def create_returns_tear_sheet(returns, positions=None,
 
     if benchmark_rets == utils.NOT_PASSED_SENTINEL:
         warnings.warn(BENCHMARK_RETS_WARNING)
+        benchmark_rets = None
 
     if benchmark_rets not in (None, utils.NOT_PASSED_SENTINEL):
         returns = utils.clip_returns_to_benchmark(returns, benchmark_rets)
@@ -955,6 +958,7 @@ def create_interesting_times_tear_sheet(
 
     if benchmark_rets == utils.NOT_PASSED_SENTINEL:
         warnings.warn(BENCHMARK_RETS_WARNING)
+        benchmark_rets = None
 
     rets_interesting = timeseries.extract_interesting_date_ranges(returns)
 

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -195,7 +195,8 @@ def create_full_tear_sheet(returns,
         factor returns and risk exposures plots
         - See create_perf_attrib_tear_sheet().
     """
-    if benchmark_rets == utils.NOT_PASSED_SENTINEL:
+    if (isinstance(benchmark_rets, str)
+            and benchmark_rets == utils.NOT_PASSED_SENTINEL):
         warnings.warn(BENCHMARK_RETS_WARNING)
         benchmark_rets = None
 
@@ -345,7 +346,8 @@ def create_simple_tear_sheet(returns,
     positions = utils.check_intraday(estimate_intraday, returns,
                                      positions, transactions)
 
-    if benchmark_rets == utils.NOT_PASSED_SENTINEL:
+    if (isinstance(benchmark_rets, str)
+            and benchmark_rets == utils.NOT_PASSED_SENTINEL):
         warnings.warn(BENCHMARK_RETS_WARNING)
         benchmark_rets = None
 
@@ -507,7 +509,8 @@ def create_returns_tear_sheet(returns, positions=None,
         If True, returns the figure that was plotted on.
     """
 
-    if benchmark_rets == utils.NOT_PASSED_SENTINEL:
+    if (isinstance(benchmark_rets, str)
+            and benchmark_rets == utils.NOT_PASSED_SENTINEL):
         warnings.warn(BENCHMARK_RETS_WARNING)
         benchmark_rets = None
 
@@ -956,7 +959,8 @@ def create_interesting_times_tear_sheet(
         If True, returns the figure that was plotted on.
     """
 
-    if benchmark_rets == utils.NOT_PASSED_SENTINEL:
+    if (isinstance(benchmark_rets, str)
+            and benchmark_rets == utils.NOT_PASSED_SENTINEL):
         warnings.warn(BENCHMARK_RETS_WARNING)
         benchmark_rets = None
 

--- a/pyfolio/utils.py
+++ b/pyfolio/utils.py
@@ -27,6 +27,7 @@ import empyrical.utils
 
 from . import pos
 from . import txn
+from .deprecate import deprecated
 
 APPROX_BDAYS_PER_MONTH = 21
 APPROX_BDAYS_PER_YEAR = 252
@@ -52,6 +53,11 @@ COLORS = ['#e6194b', '#3cb44b', '#ffe119', '#0082c8', '#f58231',
           '#911eb4', '#46f0f0', '#f032e6', '#d2f53c', '#fabebe',
           '#008080', '#e6beff', '#aa6e28', '#800000', '#aaffc3',
           '#808000', '#ffd8b1', '#000080', '#808080']
+
+DEPRECATION_WARNING = ('register_return_func and get_symbol_rets are '
+                       'deprecated and will be removed in a future version.')
+
+NOT_PASSED_SENTINEL = '__not_passed_by_user'
 
 
 def one_dec_places(x, pos):
@@ -436,6 +442,7 @@ SETTINGS = {
 }
 
 
+@deprecated(msg=DEPRECATION_WARNING)
 def register_return_func(func):
     """
     Registers the 'returns_func' that will be called for
@@ -459,6 +466,7 @@ def register_return_func(func):
     SETTINGS['returns_func'] = func
 
 
+@deprecated(msg=DEPRECATION_WARNING)
 def get_symbol_rets(symbol, start=None, end=None):
     """
     Calls the currently registered 'returns_func'


### PR DESCRIPTION
As @ssanderson pointed out, #536 introduces a breaking change to the pyfolio API. Currently, most users are not passing a benchmark and expecting analyses to run with benchmarks. The hope is to slowly wean them off this expectation.

The solution is to introduce a separate sentinel value (in `utils.py`), which is just some sufficiently unlikely string (in this particular instance, `'__not_passed_by_user'`). If users don't pass anything, we warn them. If users pass `None` or a `pd.Series`, the analysis will run with the current behavior silently.

cc @twiecki 