### PR TITLE
BUG Iterate through factors

### DIFF
--- a/pyfolio/perf_attrib.py
+++ b/pyfolio/perf_attrib.py
@@ -452,7 +452,9 @@ def plot_factor_contribution_to_perf(
         ['total_returns', 'common_returns'], axis='columns', errors='ignore'
     )
 
-    factors_cumulative = ep.cum_returns(factors_to_plot)
+    factors_cumulative = pd.DataFrame()
+    for factor in factors_to_plot:
+        factors_cumulative[factor] = ep.cum_returns(factors_to_plot[factor])
 
     for col in factors_cumulative:
         ax.plot(factors_cumulative[col])


### PR DESCRIPTION
Not sure if this is an issue related to empyrical 0.5, but I was getting this when running perf attrib tear sheets recently:
```
<ipython-input-2-b44c899798c2> in <module>()
     58                           factor_loadings=fl_cut,
     59                           live_start_date=oos_start_date,
---> 60                           header_rows=OrderedDict(redacted)
     61 
     62 

/home/jovyan/.local/share/virtualenvs/sheets-wMgbfHcF/src/pyfolio/pyfolio/tears.py in create_full_tear_sheet(returns, positions, transactions, market_data, benchmark_rets, slippage, live_start_date, sector_mappings, bayesian, round_trips, estimate_intraday, hide_positions, cone_std, bootstrap, unadjusted_returns, risk, style_factor_panel, sectors, caps, shares_held, volumes, percentile, turnover_denom, set_context, factor_returns, factor_loadings, pos_in_dollars, header_rows, factor_partitions)
    253                                           factor_loadings, transactions,
    254                                           pos_in_dollars=pos_in_dollars,
--> 255                                           factor_partitions=factor_partitions)
    256 
    257     if bayesian:

/home/jovyan/.local/share/virtualenvs/sheets-wMgbfHcF/src/pyfolio/pyfolio/plotting.py in call_w_context(*args, **kwargs)
     50         if set_context:
     51             with plotting_context(), axes_style():
---> 52                 return func(*args, **kwargs)
     53         else:
     54             return func(*args, **kwargs)

/home/jovyan/.local/share/virtualenvs/sheets-wMgbfHcF/src/pyfolio/pyfolio/tears.py in create_perf_attrib_tear_sheet(returns, positions, factor_returns, factor_loadings, transactions, pos_in_dollars, return_fig, factor_partitions)
   1582                 title=(
   1583                     'Cumulative common {} returns attribution'
-> 1584                 ).format(factor_type)
   1585             )
   1586             current_section += 1

/home/jovyan/.local/share/virtualenvs/sheets-wMgbfHcF/src/pyfolio/pyfolio/perf_attrib.py in plot_factor_contribution_to_perf(perf_attrib_data, ax, title)
    456     )
    457 
--> 458     factors_cumulative = ep.cum_returns(factors_to_plot)
    459 
    460     for col in factors_cumulative:

/home/jovyan/.local/share/virtualenvs/sheets-wMgbfHcF/local/lib/python2.7/site-packages/empyrical/stats.pyc in cum_returns(returns, starting_value, out)
    244 
    245     nanmask = np.isnan(returns)
--> 246     if np.any(nanmask):
    247         returns = returns.copy()
    248         returns[nanmask] = 0

/home/jovyan/.local/share/virtualenvs/sheets-wMgbfHcF/local/lib/python2.7/site-packages/pandas/core/generic.pyc in __nonzero__(self)
   1119         raise ValueError("The truth value of a {0} is ambiguous. "
   1120                          "Use a.empty, a.bool(), a.item(), a.any() or a.all()."
-> 1121                          .format(self.__class__.__name__))
   1122 
   1123     __bool__ = __nonzero__

ValueError: The truth value of a Series is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
ValueError: The truth value of a Series is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```

This PR fixes the issue by iterating through the factors instead of sending the df to `empyrical.cum_returns`. There is probably a better way to fix this, but it's blocking me on something critical. Just using this branch as a temporary fix and figured I'd open a PR in case we want to merge.