### PR TITLE
DOC: fix docstring for rolling volatility

### DIFF
--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -900,8 +900,9 @@ def plot_rolling_volatility(returns, factor_returns=None,
         Daily returns of the strategy, noncumulative.
          - See full explanation in tears.create_full_tear_sheet.
     factor_returns : pd.Series, optional
-        Daily noncumulative returns of the benchmark factor to which betas are
-        computed. Usually a benchmark such as market returns.
+        Daily noncumulative returns of the benchmark factor for which the
+        benchmark rolling volatility is computed. Usually a benchmark such
+        as market returns.
          - This is in the same style as returns.
     rolling_window : int, optional
         The days window over which to compute the volatility.


### PR DESCRIPTION
While reviewing #564, I noticed a small error in the docstring for `plot_rolling_volatility`.