### PR TITLE
fix error when benchmark_rets is None

### DIFF
--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -950,8 +950,8 @@ def create_interesting_times_tear_sheet(
     if benchmark_rets is not None:
         returns = utils.clip_returns_to_benchmark(returns, benchmark_rets)
 
-    bmark_interesting = timeseries.extract_interesting_date_ranges(
-        benchmark_rets)
+        bmark_interesting = timeseries.extract_interesting_date_ranges(
+            benchmark_rets)
 
     num_plots = len(rets_interesting)
     # 2 plots, 1 row; 3 plots, 2 rows; 4 plots, 2 rows; etc.


### PR DESCRIPTION
As titled, when `benchmark_rets=None`, `timeseries.extract_interesting_date_ranges(benchmark_rets)` will throw the error "AttributeError: 'NoneType' object has no attribute 'copy'".

This issue is also reported here: https://github.com/quantopian/pyfolio/issues/556#issuecomment-412255346