### PR TITLE
ADD: Apply price_multiplier in Equity and Future objects to positions…

### DIFF
--- a/pyfolio/interesting_periods.py
+++ b/pyfolio/interesting_periods.py
@@ -25,7 +25,7 @@ PERIODS = OrderedDict()
 PERIODS['Dotcom'] = (pd.Timestamp('20000310'), pd.Timestamp('20000910'))
 
 # Lehmann Brothers
-PERIODS['Lehmann'] = (pd.Timestamp('20080801'), pd.Timestamp('20081001'))
+PERIODS['Lehman'] = (pd.Timestamp('20080801'), pd.Timestamp('20081001'))
 
 # 9/11
 PERIODS['9/11'] = (pd.Timestamp('20010911'), pd.Timestamp('20011011'))

--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -1186,7 +1186,7 @@ def show_and_plot_top_positions(returns, positions_alloc,
             ax.legend(loc=legend_loc)
 
         ax.set_xlim((returns.index[0], returns.index[-1]))
-        ax.set_ylabel('Exposure by stock')
+        ax.set_ylabel('Exposure by holding')
 
         if hide_positions:
             ax.legend_.remove()


### PR DESCRIPTION
… to get adjusted notionals.

Per [Issue 570](https://github.com/quantopian/pyfolio/issues/570), `pyfolio` was not applying Equity or Future multipliers. Properly defined `zipline.asset` objects `Equity` and `Future` contain meta-data, accessible with the property `.price_multiplier`, which indicates what the quoted holding size should be multiplied by to get a notional value. This PR adds this multiplication in the `extract_pos(positions, cash)` function in `pos.py`, which is called by `pf.utils.extract_rets_pos_txn_from_zipline(results)`. There is a minor change to axis labeling (removing the word "stock" in favor of "holding") and a typo fix ("Lehmann" corrected to "Lehman").