### PR TITLE
Dynamic setting of limit of y axis for rolling portfolio beta plot

### DIFF
--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -884,7 +884,8 @@ def plot_rolling_beta(returns, factor_returns, legend_loc='best',
     ax.legend(['6-mo',
                '12-mo'],
               loc=legend_loc, frameon=True, framealpha=0.5)
-    ax.set_ylim((-1.0, 1.0))
+    lim = ax.get_ylim()
+    ax.set_ylim(lim)
     return ax
 
 


### PR DESCRIPTION
The rolling portfolio beta plot currently has a statically defined y axis limit, which ranges from -1 to 1. This sometimes results in plots like the following:

![screenshot from 2018-12-17 18-33-16](https://user-images.githubusercontent.com/26192117/50123083-6141d900-022d-11e9-9621-03d571e2f8ad.png)

Code in PR changes this to a dynamic solution, which makes plots like this: 

![screenshot from 2018-12-17 18-29-22](https://user-images.githubusercontent.com/26192117/50123188-baaa0800-022d-11e9-9972-ab876de79342.png)
