### PR TITLE
removing deprecated pd.TimeGrouper and using the .xs multi level indexing versus []

### DIFF
--- a/pyfolio/capacity.py
+++ b/pyfolio/capacity.py
@@ -18,10 +18,9 @@ def daily_txns_with_bar_data(transactions, market_data):
     transactions : pd.DataFrame
         Prices and amounts of executed trades. One row per trade.
         - See full explanation in tears.create_full_tear_sheet
-    market_data : pd.DataFrame
-        Daily market_data
-        - DataFrame has a multi-index index, one level is dates and another is
-        market_data contains volume & price, equities as columns
+    market_data : pd.Panel
+        Contains "volume" and "price" DataFrames for the tickers
+        in the passed positions DataFrames
 
     Returns
     -------
@@ -35,8 +34,9 @@ def daily_txns_with_bar_data(transactions, market_data):
     txn_daily = pd.DataFrame(transactions.assign(
         amount=abs(transactions.amount)).groupby(
         ['symbol', pd.Grouper(freq='D')]).sum()['amount'])
-    txn_daily['price'] = market_data.xs('price', level=1).unstack()
-    txn_daily['volume'] = market_data.xs('volume', level=1).unstack()
+        # ['symbol', pd.TimeGrouper('D')]).sum()['amount'])
+    txn_daily['price'] = market_data.xs('price', level='market_data').unstack()
+    txn_daily['volume'] = market_data.xs('volume', level='market_data').unstack()
 
     txn_daily = txn_daily.reset_index().set_index('date')
 
@@ -64,10 +64,10 @@ def days_to_liquidate_positions(positions, market_data,
     positions: pd.DataFrame
         Contains daily position values including cash
         - See full explanation in tears.create_full_tear_sheet
-    market_data : pd.DataFrame
-        Daily market_data
-        - DataFrame has a multi-index index, one level is dates and another is
-        market_data contains volume & price, equities as columns
+    market_data : pd.Panel
+        Panel with items axis of 'price' and 'volume' DataFrames.
+        The major and minor axes should match those of the
+        the passed positions DataFrame (same dates and symbols).
     max_bar_consumption : float
         Max proportion of a daily bar that can be consumed in the
         process of liquidating a position.
@@ -84,7 +84,8 @@ def days_to_liquidate_positions(positions, market_data,
         Datetime index, symbols as columns.
     """
 
-    DV = market_data.xs('volume', level=1) * market_data.xs('price', level=1)
+   #  DV = market_data['volume'] * market_data['price']
+    DV = market_data.xs('volume', level='market_data') * market_data.xs('price', level='market_data')
     roll_mean_dv = DV.rolling(window=mean_volume_window,
                               center=False).mean().shift()
     roll_mean_dv = roll_mean_dv.replace(0, np.nan)
@@ -112,10 +113,10 @@ def get_max_days_to_liquidate_by_ticker(positions, market_data,
     positions: pd.DataFrame
         Contains daily position values including cash
         - See full explanation in tears.create_full_tear_sheet
-    market_data : pd.DataFrame
-        Daily market_data
-        - DataFrame has a multi-index index, one level is dates and another is
-        market_data contains volume & price, equities as columns
+    market_data : pd.Panel
+        Panel with items axis of 'price' and 'volume' DataFrames.
+        The major and minor axes should match those of the
+        the passed positions DataFrame (same dates and symbols).
     max_bar_consumption : float
         Max proportion of a daily bar that can be consumed in the
         process of liquidating a position.
@@ -169,10 +170,10 @@ def get_low_liquidity_transactions(transactions, market_data,
     transactions : pd.DataFrame
         Prices and amounts of executed trades. One row per trade.
          - See full explanation in create_full_tear_sheet.
-    market_data : pd.DataFrame
-        Daily market_data
-        - DataFrame has a multi-index index, one level is dates and another is
-        market_data contains volume & price, equities as columns
+    market_data : pd.Panel
+        Panel with items axis of 'price' and 'volume' DataFrames.
+        The major and minor axes should match those of the
+        the passed positions DataFrame (same dates and symbols).
     last_n_days : integer
         Compute for only the last n days of the passed backtest data.
     """

--- a/pyfolio/capacity.py
+++ b/pyfolio/capacity.py
@@ -34,7 +34,6 @@ def daily_txns_with_bar_data(transactions, market_data):
     txn_daily = pd.DataFrame(transactions.assign(
         amount=abs(transactions.amount)).groupby(
         ['symbol', pd.Grouper(freq='D')]).sum()['amount'])
-        # ['symbol', pd.TimeGrouper('D')]).sum()['amount'])
     txn_daily['price'] = market_data.xs('price', level='market_data').unstack()
     txn_daily['volume'] = market_data.xs('volume', level='market_data').unstack()
 


### PR DESCRIPTION
the capacity tearsheet had several errors when following the format of market_data as found in the /pyfolio/tests

```
dates = pd.date_range(start='2015-01-01', freq='D', periods=3)
positions = pd.DataFrame([[1.0, 3.0, 0.0],
                       [0.0, 1.0, 1.0],
                       [3.0, 0.0, 1.0]],
                      columns=['A', 'B', 'cash'], index=dates)

transactions = pd.DataFrame(data=[[1, 100000, 10, 'A']] * len(dates),
                         columns=['sid', 'amount', 'price', 'symbol'],
                         index=dates)

volume = pd.DataFrame([[1.0, 3.0],
                    [2.0, 2.0],
                    [3.0, 1.0]],
                   columns=['A', 'B'], index=dates)
volume.index.name = 'dt'
volume = volume * 1000000
volume['market_data'] = 'volume'
price = pd.DataFrame([[1.0, 1.0]] * len(dates),
                  columns=['A', 'B'], index=dates)
price.index.name = 'dt'
price['market_data'] = 'price'
market_data = pd.concat([volume, price]).reset_index().set_index(
    ['dt', 'market_data'])
```
using this example you have a 2 level index whereby you are then calling market data, originally the indexer was ['price'] which was causing errors and non-explicit. using the .xs makes it much clearer and also functional.

pd.TimeGrouper has been deprecated and has been replaced by pd.Grouper, the parameter remains the same of `'D'` for pd.Grouper(freq='D') 