### PR TITLE
Empyrical backwards compat

### DIFF
--- a/pyfolio/pos.py
+++ b/pyfolio/pos.py
@@ -24,7 +24,7 @@ try:
 except ImportError:
     ZIPLINE = False
     warnings.warn(
-        'Module "zipline.assets" not found; mutltipliers will not be applied' +
+        'Module "zipline.assets" not found; multipliers will not be applied'
         ' to position notionals.'
     )
 

--- a/pyfolio/tests/test_perf_attrib.py
+++ b/pyfolio/tests/test_perf_attrib.py
@@ -11,6 +11,17 @@ from pyfolio.perf_attrib import (
 )
 
 
+def _empyrical_compat_perf_attrib_result(index, columns, data):
+    if ep.__version__ < '0.5.2':
+        # Newer columns were added in empyrical v0.5.2. These exist in older
+        # and newer empyrical:
+        columns = ['risk_factor1', 'risk_factor2', 'common_returns',
+                   'specific_returns', 'total_returns']
+        data = {k: v for k, v in data.items() if k in columns}
+
+    return pd.DataFrame(index=index, columns=columns, data=data)
+
+
 def generate_toy_risk_model_output(start_date='2017-01-01', periods=10,
                                    num_styles=2):
     """
@@ -115,7 +126,7 @@ class PerfAttribTestCase(unittest.TestCase):
                   'risk_factor2': [0.25, 0.25, 0.25, 0.25]}
         )
 
-        expected_perf_attrib_output = pd.DataFrame(
+        expected_perf_attrib_output = _empyrical_compat_perf_attrib_result(
             index=dts,
             columns=['risk_factor1', 'risk_factor2', 'total_returns',
                      'common_returns', 'specific_returns',
@@ -158,7 +169,7 @@ class PerfAttribTestCase(unittest.TestCase):
                                                               factor_returns,
                                                               factor_loadings)
 
-        expected_perf_attrib_output = pd.DataFrame(
+        expected_perf_attrib_output = _empyrical_compat_perf_attrib_result(
             index=dts,
             columns=['risk_factor1', 'risk_factor2', 'total_returns',
                      'common_returns', 'specific_returns',

--- a/setup.py
+++ b/setup.py
@@ -39,10 +39,7 @@ classifiers = ['Development Status :: 4 - Beta',
                'Topic :: Scientific/Engineering :: Mathematics',
                'Operating System :: OS Independent']
 
-if (sys.version_info.major, sys.version_info.minor) >= (3, 3):
-    support_ipython_6 = True
-else:
-    support_ipython_6 = False
+support_ipython_6 = (sys.version_info >= (3, 3))
 
 install_reqs = [
     'ipython>=3.2.3' if support_ipython_6 else 'ipython>=3.2.3, <6',

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ install_reqs = [
     'scipy>=0.14.0',
     'scikit-learn>=0.16.1',
     'seaborn>=0.7.1',
-    'empyrical>=0.5.2'
+    'empyrical>=0.5.0',
 ]
 
 test_reqs = ['nose>=1.3.7', 'nose-parameterized>=0.5.0', 'runipy>=0.1.3']


### PR DESCRIPTION
@twiecki It looks like the only effect of a [downgraded empyrical](https://github.com/quantopian/empyrical/compare/0.5.0...0.5.2#diff-8c09a1d2ae20c79b6ee944ea854780a4L92-R114) is that newer columns (`'tilt_returns', 'timing_returns'`) are missing from `perf_attrib` output. pyfolio itself works fine with the older empyrical (except for the tests that need compat here).

Adding the backwards compat enables some of our existing environments to use newest pyfolio without yet upgrading empyrical. We'll do that too, but this decouples the two tasks.