### PR TITLE
various fix to be able to dump correctly an html report in local batch mode

### DIFF
--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -1221,7 +1221,7 @@ def extract_interesting_date_ranges(returns, periods=None):
     if periods is None:
         periods = PERIODS
     returns_dupe = returns.copy()
-    returns_dupe.index = returns_dupe.index.map(pd.Timestamp)
+    returns_dupe.index = returns_dupe.index.map(lambda t: pd.to_datetime(t.replace(tzinfo=None)).to_pydatetime())
     ranges = OrderedDict()
     for name, (start, end) in periods.items():
         try:

--- a/pyfolio/utils.py
+++ b/pyfolio/utils.py
@@ -216,7 +216,7 @@ def print_table(table,
         # Inject the new HTML
         html = html.replace('<thead>', '<thead>' + rows)
 
-    display(HTML(html))
+    display(HTML(html).data)
 
 
 def standardize_data(x):


### PR DESCRIPTION
various fix to be able to dump correctly an html report of a full tear sheet when using pyfolio in local batch mode (ie outside a notebook).
Html is written to stdout
Note: I did not test inside a notebook
