### PR TITLE
compatible with pandas 1.2

### DIFF
--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -791,7 +791,7 @@ def plot_rolling_returns(returns,
 
     if factor_returns is not None:
         cum_factor_returns = ep.cum_returns(
-            factor_returns[cum_rets.index], 1.0)
+            factor_returns.reindex(index=cum_rets.index), 1.0)
         cum_factor_returns.plot(lw=2, color='gray',
                                 label=factor_returns.name, alpha=0.60,
                                 ax=ax, **kwargs)

--- a/pyfolio/round_trips.py
+++ b/pyfolio/round_trips.py
@@ -77,12 +77,12 @@ def agg_all_long_short(round_trips, col, stats_dict):
     stats_all = (round_trips
                  .assign(ones=1)
                  .groupby('ones')[col]
-                 .agg(stats_dict)
+                 .agg(**stats_dict)
                  .T
                  .rename(columns={1.0: 'All trades'}))
     stats_long_short = (round_trips
                         .groupby('long')[col]
-                        .agg(stats_dict)
+                        .agg(**stats_dict)
                         .T
                         .rename(columns={False: 'Short trades',
                                          True: 'Long trades'}))
@@ -378,7 +378,7 @@ def gen_round_trip_stats(round_trips):
                                           RETURN_STATS)
 
     stats['symbols'] = \
-        round_trips.groupby('symbol')['returns'].agg(RETURN_STATS).T
+        round_trips.groupby('symbol')['returns'].agg(**RETURN_STATS).T
 
     return stats
 

--- a/pyfolio/txn.py
+++ b/pyfolio/txn.py
@@ -202,5 +202,6 @@ def get_turnover(positions, transactions, denominator='AGB'):
 
     denom.index = denom.index.normalize()
     turnover = traded_value.div(denom, axis='index')
-    turnover = turnover.fillna(0)
+    with pd.option_context('mode.use_inf_as_na', True):
+        turnover = turnover.fillna(0)
     return turnover


### PR DESCRIPTION
change some incompatible pandas usage to support working with pandas v1.2

* SpecificationError: nested renamer is not supported while agg(): have to use `agg(**dict)` instead
* KeyError: "Passing list-likes to .loc or [] with any missing labels is no longer supported: have to use `reindex` instead
* OverflowError: cannot convert float infinity to integer. because inf is not consider to be na value by default