### PR TITLE
[FIX]: Error when never ending drawdown

### DIFF
--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -437,6 +437,8 @@ def plot_drawdown_periods(returns, top=10, ax=None, **kwargs):
     colors = sns.cubehelix_palette(len(df_drawdowns))[::-1]
     for i, (peak, recovery) in df_drawdowns[
             ['Peak date', 'Recovery date']].iterrows():
+        if pd.isnull(peak):
+            break
         if pd.isnull(recovery):
             recovery = returns.index[-1]
         ax.fill_between((peak, recovery),


### PR DESCRIPTION
When there's just one single never ending drawdown period the code breaks when computing the drawdown plots.