### PR TITLE
docs: Fix a few typos

### DIFF
--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -183,7 +183,7 @@ your dependencies, specifically, `pandas>=0.18.0`, `seaborn>=0.6.0` and
   Wiecki](https://github.com/twiecki)
 
 ### Bug fixes
-* Many depracation fixes for Pandas 0.18.0, seaborn 0.6.0, and zipline 0.8.4
+* Many deprecation fixes for Pandas 0.18.0, seaborn 0.6.0, and zipline 0.8.4
 
 
 ## v0.4.0 (Dec 10, 2015)

--- a/pyfolio/capacity.py
+++ b/pyfolio/capacity.py
@@ -208,12 +208,12 @@ def apply_slippage_penalty(returns, txn_daily, simulate_starting_capital,
     returns : pd.Series
         Time series of daily returns.
     txn_daily : pd.Series
-        Daily transaciton totals, closing price, and daily volume for
+        Daily transaction totals, closing price, and daily volume for
         each traded name. See price_volume_daily_txns for more details.
     simulate_starting_capital : integer
         capital at which we want to test
     backtest_starting_capital: capital base at which backtest was
-        origionally run. impact: See Zipline volumeshare slippage model
+        originally run. impact: See Zipline volumeshare slippage model
     impact : float
         Scales the size of the slippage penalty.
 

--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -72,7 +72,7 @@ def plotting_context(context='notebook', font_scale=1.5, rc=None):
         Config flags.
         By default, {'lines.linewidth': 1.5}
         is being used and will be added to any
-        rc passed in, unless explicitly overriden.
+        rc passed in, unless explicitly overridden.
 
     Returns
     -------
@@ -455,7 +455,7 @@ def plot_drawdown_periods(returns, top=10, ax=None, **kwargs):
 
 def plot_drawdown_underwater(returns, ax=None, **kwargs):
     """
-    Plots how far underwaterr returns are over time, or plots current
+    Plots how far underwater returns are over time, or plots current
     drawdown vs. date.
 
     Parameters
@@ -753,7 +753,7 @@ def plot_rolling_returns(returns,
         volatilities. Requires passing of benchmark_rets.
     cone_function : function, optional
         Function to use when generating forecast probability cone.
-        The function signiture must follow the form:
+        The function signature must follow the form:
         def cone(in_sample_returns (pd.Series),
                  days_to_project_forward (int),
                  cone_std= (float, or tuple),
@@ -1408,7 +1408,7 @@ def plot_slippage_sweep(returns, positions, transactions,
         Prices and amounts of executed trades. One row per trade.
          - See full explanation in tears.create_full_tear_sheet.
     slippage_params: tuple
-        Slippage pameters to apply to the return time series (in
+        Slippage parameters to apply to the return time series (in
         basis points).
     ax : matplotlib.Axes, optional
         Axes upon which to plot.
@@ -1877,7 +1877,7 @@ def plot_cones(name, bounds, oos_returns, num_samples=1000, ax=None,
         Account name to be used as figure title.
     bounds : pandas.core.frame.DataFrame
         Contains upper and lower cone boundaries. Column names are
-        strings corresponding to the number of standard devations
+        strings corresponding to the number of standard deviations
         above (positive) or below (negative) the projected mean
         cumulative returns.
     oos_returns : pandas.core.frame.DataFrame
@@ -1890,7 +1890,7 @@ def plot_cones(name, bounds, oos_returns, num_samples=1000, ax=None,
     ax : matplotlib.Axes, optional
         Axes upon which to plot.
     cone_std : list of int/float
-        Number of standard devations to use in the boundaries of
+        Number of standard deviations to use in the boundaries of
         the cone. If multiple values are passed, cone bounds will
         be generated for each value.
     random_seed : int

--- a/pyfolio/round_trips.py
+++ b/pyfolio/round_trips.py
@@ -193,7 +193,7 @@ def extract_round_trips(transactions,
         DataFrame with one row per round trip.  The returns column
         contains returns in respect to the portfolio value while
         rt_returns are the returns in regards to the invested capital
-        into that partiulcar round-trip.
+        into that particular round-trip.
     """
 
     transactions = _groupby_consecutive(transactions)

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -247,7 +247,7 @@ def create_simple_tear_sheet(returns,
     - Never accept market_data input (market_data = None)
     - Never accept sector_mappings input (sector_mappings = None)
     - Never perform bootstrap analysis (bootstrap = False)
-    - Never hide posistions on top 10 holdings plot (hide_positions = False)
+    - Never hide positions on top 10 holdings plot (hide_positions = False)
     - Always use default cone_std (cone_std = (1.0, 1.5, 2.0))
 
     Parameters

--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -1120,7 +1120,7 @@ def summarize_paths(samples, cone_std=(1., 1.5, 2.), starting_value=1.):
     samples : numpy.ndarray
         Alternative paths, or series of possible outcomes.
     cone_std : list of int/float
-        Number of standard devations to use in the boundaries of
+        Number of standard deviations to use in the boundaries of
         the cone. If multiple values are passed, cone bounds will
         be generated for each value.
 
@@ -1152,7 +1152,7 @@ def forecast_cone_bootstrap(is_returns, num_days, cone_std=(1., 1.5, 2.),
     """
     Determines the upper and lower bounds of an n standard deviation
     cone of forecasted cumulative returns. Future cumulative mean and
-    standard devation are computed by repeatedly sampling from the
+    standard deviation are computed by repeatedly sampling from the
     in-sample daily returns (i.e. bootstrap). This cone is non-parametric,
     meaning it does not assume that returns are normally distributed.
 
@@ -1164,7 +1164,7 @@ def forecast_cone_bootstrap(is_returns, num_days, cone_std=(1., 1.5, 2.),
     num_days : int
         Number of days to project the probability cone forward.
     cone_std : int, float, or list of int/float
-        Number of standard devations to use in the boundaries of
+        Number of standard deviations to use in the boundaries of
         the cone. If multiple values are passed, cone bounds will
         be generated for each value.
     starting_value : int or float
@@ -1182,7 +1182,7 @@ def forecast_cone_bootstrap(is_returns, num_days, cone_std=(1., 1.5, 2.),
     -------
     pd.DataFrame
         Contains upper and lower cone boundaries. Column names are
-        strings corresponding to the number of standard devations
+        strings corresponding to the number of standard deviations
         above (positive) or below (negative) the projected mean
         cumulative returns.
     """

--- a/pyfolio/txn.py
+++ b/pyfolio/txn.py
@@ -60,7 +60,7 @@ def make_transaction_frame(transactions):
     Returns
     -------
     df : pd.DataFrame
-        Daily transaction volume and dollar ammount.
+        Daily transaction volume and dollar amount.
          - See full explanation in tears.create_full_tear_sheet.
     """
 


### PR DESCRIPTION
There are small typos in:
- WHATSNEW.md
- pyfolio/capacity.py
- pyfolio/plotting.py
- pyfolio/round_trips.py
- pyfolio/tears.py
- pyfolio/timeseries.py
- pyfolio/txn.py

Fixes:
- Should read `deviations` rather than `devations`.
- Should read `deprecation` rather than `depracation`.
- Should read `underwater` rather than `underwaterr`.
- Should read `transaction` rather than `transaciton`.
- Should read `signature` rather than `signiture`.
- Should read `positions` rather than `posistions`.
- Should read `particular` rather than `partiulcar`.
- Should read `parameters` rather than `pameters`.
- Should read `originally` rather than `origionally`.
- Should read `deviation` rather than `devation`.
- Should read `amount` rather than `ammount`.
- Should read `overridden` rather than `overriden`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md