### PR TITLE
Adjusting assertion threshold to fix flaky test

### DIFF
--- a/pyfolio/tests/test_timeseries.py
+++ b/pyfolio/tests/test_timeseries.py
@@ -338,14 +338,14 @@ class TestBootstrap(TestCase):
         assert_almost_equal(
             np.mean(samples),
             mean_of_mean,
-            3,
+            2,
             'Mean of bootstrap does not match theoretical mean of'
             'sampling distribution')
 
         assert_almost_equal(
             np.std(samples),
             sd_of_mean,
-            3,
+            2,
             'SD of bootstrap does not match theoretical SD of'
             'sampling distribution')
 


### PR DESCRIPTION
Hi,

I observed that the test `test_calc_bootstrap` sometimes fails when the seed setting line such as `np .random_seed(123)` is removed. It failed 55 times out of 500 times that i ran. I adjusted the assertions in the test to make sure that they always pass. Please let me know if this change looks reasonable. Since the test is more stable, do you think I can also remove the seed-setting line?

Happy to include any other suggestions.