### PR TITLE
Bug fixes for tear sheet plots

### DIFF
--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -1384,7 +1384,6 @@ def plot_turnover(returns, transactions, positions, turnover_denom='AGB',
               loc=legend_loc, frameon=True, framealpha=0.5)
     ax.set_title('Daily turnover')
     ax.set_xlim((returns.index[0], returns.index[-1]))
-    ax.set_ylim((0, 2))
     ax.set_ylabel('Turnover')
     ax.set_xlabel('')
     return ax

--- a/pyfolio/tears.py
+++ b/pyfolio/tears.py
@@ -202,6 +202,7 @@ def create_full_tear_sheet(returns,
 
         if transactions is not None:
             create_txn_tear_sheet(returns, positions, transactions,
+                                  turnover_denom=turnover_denom,
                                   unadjusted_returns=unadjusted_returns,
                                   estimate_intraday=False,
                                   set_context=set_context)


### PR DESCRIPTION
### Bug fix 1 (`tears.py`)
In `create_full_tear_sheet` function, `turnover_denom` was not passed to `create_txn_tear_sheet` function (so this fix added it). 

Without this fix, `plotting.plot_turnover` and `plotting.plot_daily_turnover_hist` use the default value of `'AGB'` when they are called from `create_full_tear_sheet` (via `create_txn_tear_sheet`).

### Bug fix 2 (`plotting.py`)
Deleted `ax.set_ylim((0, 2))` from `plot_turnover` function, because daily turnover can be over 2.